### PR TITLE
feat: realtime chat/graph UI and agent-office real data sync

### DIFF
--- a/.claude/hooks/agent-task-tracker.py
+++ b/.claude/hooks/agent-task-tracker.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+API_BASE = os.getenv("AGENT_TASK_API_BASE", "http://127.0.0.1:8765")
+TIMEOUT_ARGS = ["--connect-timeout", "2", "--max-time", "5"]
+
+
+def _extract_task_id(tool_name: str, tool_input: dict[str, Any], tool_response: Any) -> str | None:
+    if tool_name == "TaskCreate":
+        if isinstance(tool_response, dict):
+            return tool_response.get("task_id") or tool_response.get("id")
+        return None
+    if tool_name == "TaskUpdate":
+        return tool_input.get("task_id") or tool_input.get("taskId")
+    return None
+
+
+def _spawn_curl(method: str, url: str, payload: dict[str, Any]) -> None:
+    cmd = [
+        "curl",
+        "-sS",
+        "-X",
+        method,
+        *TIMEOUT_ARGS,
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        json.dumps(payload, ensure_ascii=False),
+        url,
+    ]
+    subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return 0
+        event = json.loads(raw)
+    except Exception:
+        return 0
+
+    tool_name = event.get("tool_name")
+    if tool_name not in ("TaskCreate", "TaskUpdate"):
+        return 0
+
+    tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else {}
+    tool_response = event.get("tool_response")
+    session_id = event.get("session_id")
+    task_id = _extract_task_id(tool_name, tool_input, tool_response)
+    if not task_id:
+        return 0
+
+    if tool_name == "TaskCreate":
+        payload = {
+            "task_id": task_id,
+            "session_id": session_id,
+            "agent_type": tool_input.get("agent_type"),
+            "team_name": tool_input.get("team_name"),
+            "subject": tool_input.get("subject") or tool_input.get("title") or f"Task {task_id}",
+            "description": tool_input.get("description"),
+            "status": tool_input.get("status", "pending"),
+            "metadata_json": {"source": "post_tool_use_hook"},
+        }
+        _spawn_curl("POST", f"{API_BASE}/api/agent-tasks", payload)
+        return 0
+
+    payload = {
+        "task_id": task_id,
+        "session_id": session_id,
+        "status": tool_input.get("status"),
+        "subject": tool_input.get("subject"),
+        "description": tool_input.get("description"),
+        "files_modified": tool_input.get("files_modified"),
+        "metadata_json": {"source": "post_tool_use_hook_update"},
+    }
+    _spawn_curl("PUT", f"{API_BASE}/api/agent-tasks/{task_id}", payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/agent-task-tracker.py
+++ b/.claude/hooks/agent-task-tracker.py
@@ -43,6 +43,20 @@ def _spawn_curl(method: str, url: str, payload: dict[str, Any]) -> None:
     )
 
 
+def _spawn_presence_upsert(tool_input: dict[str, Any], session_id: str | None) -> None:
+    agent_name = tool_input.get("agent_name") or tool_input.get("agent_type")
+    if not agent_name:
+        return
+    payload = {
+        "agent_name": agent_name,
+        "agent_type": tool_input.get("agent_type"),
+        "session_id": session_id,
+        "team_name": tool_input.get("team_name"),
+        "state": "active",
+    }
+    _spawn_curl("POST", f"{API_BASE}/api/agent-presence", payload)
+
+
 def main() -> int:
     try:
         raw = sys.stdin.read().strip()
@@ -73,8 +87,10 @@ def main() -> int:
             "description": tool_input.get("description"),
             "status": tool_input.get("status", "pending"),
             "metadata_json": {"source": "post_tool_use_hook"},
+            "parent_task_id": tool_input.get("parent_task_id") or tool_input.get("parentTaskId"),
         }
         _spawn_curl("POST", f"{API_BASE}/api/agent-tasks", payload)
+        _spawn_presence_upsert(tool_input, session_id)
         return 0
 
     payload = {
@@ -85,8 +101,10 @@ def main() -> int:
         "description": tool_input.get("description"),
         "files_modified": tool_input.get("files_modified"),
         "metadata_json": {"source": "post_tool_use_hook_update"},
+        "parent_task_id": tool_input.get("parent_task_id") or tool_input.get("parentTaskId"),
     }
     _spawn_curl("PUT", f"{API_BASE}/api/agent-tasks/{task_id}", payload)
+    _spawn_presence_upsert(tool_input, session_id)
     return 0
 
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "TaskCreate|TaskUpdate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /Users/miyoungjang/Repository/quant/tools/.claude/hooks/agent-task-tracker.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+- What changed:
+- Why:
+
+## Linked Issues
+- Closes #
+- Refs #
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Validation
+- [ ] `python3 -m py_compile ...`
+- [ ] API smoke test on `8765`
+- [ ] UI/manual verification (if applicable)
+
+Commands/Results:
+```bash
+# command
+# result
+```
+
+## Risk / Rollback
+- Risk:
+- Rollback steps:
+
+## Checklist
+- [ ] PR title follows conventional style (`feat:`, `fix:`, `chore:`, `docs:`)
+- [ ] No direct changes to unrelated files
+- [ ] Docs updated (`README.md`, `WORKFLOW.md`, `AGENTS.md` if needed)
+- [ ] Reviewer can reproduce with listed commands
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+agent_tasks.db
+.DS_Store
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ Execution workflow is documented in:
 - Prefer `rg`/`rg --files` for search.
 - Do not modify files outside this repository unless explicitly requested.
 - Validate changes with lightweight checks before finishing.
+- Follow PR-only policy:
+  - Never merge by direct push to `main`.
+  - Use feature branch -> PR -> review -> squash merge.
 
 ## Codex Preflight Checklist
 - Git user is configured (`user.name`, `user.email`).
@@ -26,3 +29,7 @@ Execution workflow is documented in:
 - Default `--qi2-repo` now points to this repository root.
 - Run example:
   - `python3 agent_office/live_server.py --port 8765`
+
+## Collaboration Docs
+- PR and merge rules: `CONTRIBUTING.md`
+- PR template: `.github/pull_request_template.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,12 @@ This repository root is:
 
 Codex should treat this directory as the default project root.
 
+Execution workflow is documented in:
+- `WORKFLOW.md`
+
 ## Default Working Rules
 - Always run commands from this root unless a task requires a subdirectory.
+- Never inspect or modify sibling repositories unless explicitly instructed.
 - Prefer `rg`/`rg --files` for search.
 - Do not modify files outside this repository unless explicitly requested.
 - Validate changes with lightweight checks before finishing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+This repository root is:
+- `/Users/miyoungjang/Repository/quant/tools`
+
+Codex should treat this directory as the default project root.
+
+## Default Working Rules
+- Always run commands from this root unless a task requires a subdirectory.
+- Prefer `rg`/`rg --files` for search.
+- Do not modify files outside this repository unless explicitly requested.
+- Validate changes with lightweight checks before finishing.
+
+## Codex Preflight Checklist
+- Git user is configured (`user.name`, `user.email`).
+- Remote access works (`ssh -T git@github.com` and `git fetch`).
+- Codex auth is available (`~/.codex/auth.json` or `OPENAI_API_KEY`).
+- Trust level includes this repo path in `~/.codex/config.toml`.
+
+## Agent Office
+- Main server script: `agent_office/live_server.py`
+- Default `--qi2-repo` now points to this repository root.
+- Run example:
+  - `python3 agent_office/live_server.py --port 8765`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing Guide
+
+## PR-Only Merge Policy
+- Direct push to `main` is prohibited by team rule.
+- All code changes must go through a Pull Request.
+- At least 1 reviewer approval is required before merge.
+- Merge method: `Squash and merge` only.
+- All open review conversations must be resolved before merge.
+- CI/check commands in PR description must pass.
+
+## Branch Strategy
+- Base branch: `main`
+- Feature branches:
+  - `feat/<short-topic>`
+  - `fix/<short-topic>`
+  - `chore/<short-topic>`
+  - `docs/<short-topic>`
+
+Examples:
+- `feat/realtime-chat`
+- `fix/task-status-transition`
+
+## Required PR Checklist
+- Link issue(s): `Closes #...` or `Refs #...`
+- Explain scope and non-scope
+- List changed files/areas
+- Add validation steps and results
+- Include screenshots for UI changes
+- Mention rollback plan for risky changes
+
+## Local Flow
+```bash
+git checkout -b feat/<topic>
+# implement changes
+git add .
+git commit -m "feat: <summary>"
+git push -u origin feat/<topic>
+gh pr create --base main --fill
+```
+
+## Merge Flow
+1. Reviewer approval
+2. Checks green
+3. Conversation resolved
+4. Squash merge
+5. Delete feature branch
+

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Key APIs:
 - `GET /api/agent-chat/messages?room_key=general`
 - `GET /api/agent-presence`
 - `WS /ws/office`
+- `POST /api/integrations/agent-office/sync`
+
+Real data sync (from agent_office server):
+```bash
+curl -X POST http://127.0.0.1:8765/api/integrations/agent-office/sync \
+  -H "Content-Type: application/json" \
+  -d '{"source_url":"http://127.0.0.1:8766/api/agent-office/status"}'
+```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ Run:
 ```bash
 python3 -m uvicorn api.main:app --port 8765
 ```
+
+UI:
+```bash
+open http://127.0.0.1:8765/ui
+```
+
+Key APIs:
+- `GET /api/agent-tasks`
+- `GET /api/agent-graph`
+- `GET /api/agent-chat/rooms`
+- `GET /api/agent-chat/messages?room_key=general`
+- `GET /api/agent-presence`
+- `WS /ws/office`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Codex Setup (Project Root)
 - Root: `/Users/miyoungjang/Repository/quant/tools`
 - Project instructions: `AGENTS.md`
+- Execution workflow: `WORKFLOW.md`
 - Agent Office server: `agent_office/live_server.py`
 
 ## Quick Start
@@ -16,4 +17,16 @@ python3 agent_office/live_server.py --port 8765
 git config user.name
 git config user.email
 git fetch
+```
+
+## Agent Task API
+Install:
+```bash
+cd /Users/miyoungjang/Repository/quant/tools
+python3 -m pip install -r requirements-api.txt
+```
+
+Run:
+```bash
+python3 -m uvicorn api.main:app --port 8765
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # agent-team-monitor
+
+## Codex Setup (Project Root)
+- Root: `/Users/miyoungjang/Repository/quant/tools`
+- Project instructions: `AGENTS.md`
+- Agent Office server: `agent_office/live_server.py`
+
+## Quick Start
+```bash
+cd /Users/miyoungjang/Repository/quant/tools
+python3 agent_office/live_server.py --port 8765
+```
+
+## Basic Checks
+```bash
+git config user.name
+git config user.email
+git fetch
+```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Key APIs:
 - `WS /ws/office`
 - `POST /api/integrations/agent-office/sync`
 
+## Contribution Policy
+- PR-only merge workflow is mandatory.
+- See `CONTRIBUTING.md` and `.github/pull_request_template.md`.
+
 Real data sync (from agent_office server):
 ```bash
 curl -X POST http://127.0.0.1:8765/api/integrations/agent-office/sync \

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -44,4 +44,12 @@ Smoke test:
 curl -X POST http://127.0.0.1:8765/api/agent-tasks -H "Content-Type: application/json" -d '{"task_id":"test-1","subject":"Test task","status":"pending"}'
 curl -X PUT http://127.0.0.1:8765/api/agent-tasks/test-1 -H "Content-Type: application/json" -d '{"task_id":"test-1","status":"completed"}'
 curl http://127.0.0.1:8765/api/agent-tasks
+curl http://127.0.0.1:8765/api/agent-graph
+curl http://127.0.0.1:8765/api/agent-chat/rooms
+curl http://127.0.0.1:8765/api/agent-presence
+```
+
+UI:
+```bash
+open http://127.0.0.1:8765/ui
 ```

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,47 @@
+# Workflow Guide
+
+## Repository Scope Rule
+- Always work inside `/Users/miyoungjang/Repository/quant/tools`.
+- Do not switch to other repositories unless the user explicitly requests it.
+
+## Default Execution Rule
+- If required paths do not exist (for example `api/`, `.claude/`), create the scaffold in this repository and continue.
+- Do not pause for confirmation when the intent is clear and implementation can proceed safely.
+
+## Agent Task Tracking Epic Rule
+Process child issues in this order:
+1. `#2` DB model
+2. `#3` Pydantic schemas
+3. `#4` Service write path
+4. `#5` Service read/delete path
+5. `#6` Router
+6. `#7` App wiring
+7. `#8` Hook script
+8. `#9` Hook registration
+9. `#10` Validation/E2E docs
+
+Parallelization guidance:
+- Wave 1: `#2`, `#3`, `#8`
+- Wave 2: `#4`, `#5`, `#9`
+- Wave 3: `#6`, `#7`
+- Wave 4: `#10`
+
+## GitHub Issue Tracking Rule
+- When starting an issue: add a short `start` comment.
+- After implementation: add `done` comment with changed files and verification commands.
+- Keep parent issue `#1` as progress index.
+
+## Validation Rule
+Run at minimum:
+```bash
+python3 -m pip install -r requirements-api.txt
+python3 -m py_compile api/main.py api/database.py api/models/agent_task.py api/services/agent_task_service.py api/routers/agent_task.py .claude/hooks/agent-task-tracker.py
+python3 -m uvicorn api.main:app --port 8765
+```
+
+Smoke test:
+```bash
+curl -X POST http://127.0.0.1:8765/api/agent-tasks -H "Content-Type: application/json" -d '{"task_id":"test-1","subject":"Test task","status":"pending"}'
+curl -X PUT http://127.0.0.1:8765/api/agent-tasks/test-1 -H "Content-Type: application/json" -d '{"task_id":"test-1","status":"completed"}'
+curl http://127.0.0.1:8765/api/agent-tasks
+```

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -31,6 +31,19 @@ Parallelization guidance:
 - After implementation: add `done` comment with changed files and verification commands.
 - Keep parent issue `#1` as progress index.
 
+## PR Rule (Mandatory)
+- Do not push implementation commits directly to `main`.
+- Create a feature branch and open PR to `main`.
+- Merge only after at least one approval and validation completion.
+- Use squash merge.
+
+PR quick flow:
+```bash
+git checkout -b feat/<topic>
+git push -u origin feat/<topic>
+gh pr create --base main --fill
+```
+
 ## Validation Rule
 Run at minimum:
 ```bash

--- a/agent_office/live_server.py
+++ b/agent_office/live_server.py
@@ -1,0 +1,1085 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class AgentDef:
+    agent_id: str
+    dirs: tuple[str, ...]
+
+
+AGENTS: tuple[AgentDef, ...] = (
+    AgentDef("chief", ("api/", "web/", "engine/", "portfolio/", "scripts/", "docs/", "tests/")),
+    AgentDef("planner", ("docs/works/",)),
+    AgentDef("designer", ("web/",)),
+    AgentDef("quant", ("engine/", "discovery/", "screener/")),
+    AgentDef("data", ("pipeline/", "data_enrichment/", "news/", "models/", "llm/")),
+    AgentDef("portfolio", ("portfolio/",)),
+    AgentDef("server", ("api/",)),
+    AgentDef("frontend", ("web/",)),
+    AgentDef("qa", ("tests/", "api/tests/")),
+)
+
+PROJECTS = (
+    {
+        "id": "qi1",
+        "name": "quant-investment",
+        "roomName": "개발1실",
+        "color": "#6366f1",
+        "bgColor": "rgba(99,102,241,0.15)",
+    },
+    {
+        "id": "qi2",
+        "name": "quant-investment2",
+        "roomName": "개발2실",
+        "color": "#f59e0b",
+        "bgColor": "rgba(245,158,11,0.15)",
+    },
+)
+
+STATUS_COLOR = {
+    "active": "#22c55e",
+    "waiting_input": "#38bdf8",
+    "working": "#f59e0b",
+    "idle": "#6b7280",
+    "sleeping": "#374151",
+}
+STATUS_LABEL = {
+    "active": "Active",
+    "waiting_input": "Waiting",
+    "working": "Working",
+    "idle": "Idle",
+    "sleeping": "Sleeping",
+}
+RATE_LIMIT_TS_RE = re.compile(
+    r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z).*(rate_limit_error|would exceed your account's rate limit)"
+)
+ISO_TS_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z")
+BASH_BLOCK_RE = re.compile(r"Bash\((?P<cmd>.*?)\)", re.DOTALL)
+SECRET_RE = re.compile(r"(?i)(api[-_]?key|token|secret|password)\s*[:=]\s*([^\s\"']+)")
+FORKED_USAGE_RE = re.compile(
+    r"(?P<ts>\d{4}-\d{2}-\d{2}T[0-9:.]+Z).+Forked agent \[(?P<agent>[^\]]+)\] finished:.*totalUsage: input=(?P<input>\d+) output=(?P<output>\d+)"
+)
+BG_DONE_RE = re.compile(r'Background command "(?P<label>[^"]+)" completed \(exit code (?P<code>-?\d+)\)')
+AGENT_DONE_RE = re.compile(r'Agent "(?P<label>[^"]+)" completed')
+PR_LINK_RE = re.compile(r"https://github\.com/[\w.-]+/[\w.-]+/pull/\d+")
+BULLET_NOTE_RE = re.compile(r"[⏺•]\s+(?P<msg>.+)")
+QI1_PATH_RE = re.compile(r"/quant/quant-investment(?:/|$)")
+QI2_PATH_RE = re.compile(r"/quant/quant-investment2(?:/|$)")
+MCP_RUNNING_RE = re.compile(r"""MCP server "codex": Tool '(?:codex|codex-reply)' still running""")
+MCP_DONE_RE = re.compile(r"""MCP server "codex": Tool '(?:codex|codex-reply)' completed successfully""")
+MCP_FAIL_RE = re.compile(r"""MCP server "codex": Tool '(?:codex|codex-reply)' failed after""")
+
+EVENT_WEIGHT: dict[str, float] = {
+    "bash": 5.0,
+    "stream_chunk": 4.0,
+    "forked_usage": 4.0,
+    "tool_running": 3.0,
+    "query_input": 2.0,
+    "tool_done": 1.5,
+    "tool_failed": 1.0,
+}
+
+
+def run_git(repo: Path, args: list[str]) -> str:
+    cmd = ["git", "-C", str(repo), *args]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError:
+        return ""
+    return proc.stdout.strip()
+
+
+def branch_name(repo: Path) -> str:
+    out = run_git(repo, ["rev-parse", "--abbrev-ref", "HEAD"])
+    return out or "unknown"
+
+
+def count_commits(repo: Path, days: int, dirs: tuple[str, ...]) -> int:
+    out = run_git(
+        repo,
+        ["rev-list", "--count", "--since", f"{days}.days", "HEAD", "--", *dirs],
+    )
+    return int(out) if out.isdigit() else 0
+
+
+def tracked_files(repo: Path, dirs: tuple[str, ...]) -> int:
+    out = run_git(repo, ["ls-files", "--", *dirs])
+    if not out:
+        return 0
+    return len([line for line in out.splitlines() if line.strip()])
+
+
+def last_active(repo: Path, dirs: tuple[str, ...]) -> str | None:
+    out = run_git(repo, ["log", "-n", "1", "--pretty=format:%cI", "--", *dirs])
+    return out or None
+
+
+def has_uncommitted_changes(repo: Path, dirs: tuple[str, ...]) -> bool:
+    out = run_git(repo, ["status", "--porcelain", "--", *dirs])
+    return bool(out.strip())
+
+
+def files_changed_for_commit(repo: Path, commit_hash: str, dirs: tuple[str, ...]) -> int:
+    out = run_git(repo, ["show", "--pretty=format:", "--name-only", commit_hash, "--", *dirs])
+    if not out:
+        return 0
+    return len([line for line in out.splitlines() if line.strip()])
+
+
+def recent_activity(repo: Path, dirs: tuple[str, ...], limit: int = 2) -> list[dict[str, Any]]:
+    fmt = "%h%x1f%cI%x1f%s"
+    out = run_git(repo, ["log", f"-n{limit}", f"--pretty=format:{fmt}", "--", *dirs])
+    acts: list[dict[str, Any]] = []
+    if not out:
+        return acts
+    for row in out.splitlines():
+        parts = row.split("\x1f")
+        if len(parts) != 3:
+            continue
+        short_hash, date_iso, message = parts
+        acts.append(
+            {
+                "hash": short_hash,
+                "message": message,
+                "date": date_iso,
+                "files_changed": files_changed_for_commit(repo, short_hash, dirs),
+            }
+        )
+    return acts
+
+
+def parse_iso(iso_str: str | None) -> datetime | None:
+    if not iso_str:
+        return None
+    try:
+        return datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def state_from_last_active(last_active_iso: str | None, now_utc: datetime) -> str:
+    dt = parse_iso(last_active_iso)
+    if dt is None:
+        return "sleeping"
+
+    age = now_utc - dt.astimezone(timezone.utc)
+    if age <= timedelta(minutes=20):
+        return "active"
+    if age <= timedelta(hours=2):
+        return "waiting_input"
+    if age <= timedelta(days=3):
+        return "working"
+    if age <= timedelta(days=14):
+        return "idle"
+    return "sleeping"
+
+
+def detect_claude_rate_limit(now_utc: datetime) -> dict[str, Any]:
+    debug_dir = Path.home() / ".claude" / "debug"
+    if not debug_dir.exists():
+        return {"is_limited": False, "last_hit_at": None}
+
+    candidates = sorted(
+        [p for p in debug_dir.glob("*.txt") if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:8]
+    newest_hit: datetime | None = None
+
+    for path in candidates:
+        try:
+            with path.open("rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(size - 220_000, 0))
+                tail = f.read().decode("utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        for m in RATE_LIMIT_TS_RE.finditer(tail):
+            dt = parse_iso(m.group(1))
+            if dt is None:
+                continue
+            dt_utc = dt.astimezone(timezone.utc)
+            if newest_hit is None or dt_utc > newest_hit:
+                newest_hit = dt_utc
+
+    if newest_hit is None:
+        return {"is_limited": False, "last_hit_at": None}
+
+    is_limited = (now_utc - newest_hit) <= timedelta(hours=6)
+    return {"is_limited": is_limited, "last_hit_at": newest_hit.isoformat()}
+
+
+def detect_claude_code_state(now_utc: datetime, is_limited: bool) -> dict[str, Any]:
+    debug_dir = Path.home() / ".claude" / "debug"
+    newest_seen: datetime | None = None
+
+    if debug_dir.exists():
+        for p in debug_dir.glob("*.txt"):
+            try:
+                dt = datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc)
+            except OSError:
+                continue
+            if newest_seen is None or dt > newest_seen:
+                newest_seen = dt
+
+    if is_limited:
+        return {
+            "state": "waiting_input",
+            "label": "Limited",
+            "color": "#f87171",
+            "last_active": newest_seen.isoformat() if newest_seen else None,
+        }
+    if newest_seen is None:
+        return {"state": "idle", "label": "Idle", "color": STATUS_COLOR["idle"], "last_active": None}
+
+    age = now_utc - newest_seen
+    if age <= timedelta(minutes=3):
+        state = "active"
+    elif age <= timedelta(minutes=20):
+        state = "waiting_input"
+    elif age <= timedelta(hours=4):
+        state = "working"
+    else:
+        state = "idle"
+
+    return {
+        "state": state,
+        "label": STATUS_LABEL[state],
+        "color": STATUS_COLOR[state],
+        "last_active": newest_seen.isoformat(),
+    }
+
+
+def sanitize_command(cmd: str) -> str:
+    s = " ".join(cmd.strip().split())
+    s = SECRET_RE.sub(r"\1=***", s)
+    s = re.sub(r"(?i)(bearer\s+)[a-z0-9._-]+", r"\1***", s)
+    return s[:220]
+
+
+def infer_cmd_status(context: str) -> tuple[str, str]:
+    lower = context.lower()
+    if "running in the background" in lower or "running" in lower:
+        return ("running", "Running")
+    if "failed" in lower or "error" in lower:
+        return ("failed", "Failed")
+    return ("done", "Done")
+
+
+def parse_recent_commands(now_utc: datetime, limit: int = 10) -> list[dict[str, Any]]:
+    debug_dir = Path.home() / ".claude" / "debug"
+    if not debug_dir.exists():
+        return []
+
+    files = sorted(
+        [p for p in debug_dir.glob("*.txt") if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:8]
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for path in files:
+        try:
+            with path.open("rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(size - 300_000, 0))
+                text = f.read().decode("utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        file_ts = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+        for m in BASH_BLOCK_RE.finditer(text):
+            cmd = sanitize_command(m.group("cmd"))
+            if not cmd:
+                continue
+            post = text[m.end() : m.end() + 280]
+            status, label = infer_cmd_status(post)
+            ts_match = ISO_TS_RE.search(text[max(0, m.start() - 220) : m.start()])
+            ts = parse_iso(ts_match.group(0)).isoformat() if ts_match and parse_iso(ts_match.group(0)) else file_ts
+            dedupe = (cmd, status)
+            if dedupe in seen:
+                continue
+            seen.add(dedupe)
+            rows.append(
+                {
+                    "cmd": cmd,
+                    "status": status,
+                    "label": label,
+                    "time": ts,
+                    "source": path.name,
+                }
+            )
+            if len(rows) >= limit:
+                return rows
+    return rows
+
+
+def parse_recent_runtime_notes(now_utc: datetime, repo_map: dict[str, Path], limit: int = 12) -> list[dict[str, Any]]:
+    debug_dir = Path.home() / ".claude" / "debug"
+    if not debug_dir.exists():
+        return []
+    repo_markers = {k: str(v).replace("\\", "/") for k, v in repo_map.items()}
+
+    files = sorted(
+        [p for p in debug_dir.glob("*.txt") if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:10]
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for path in files:
+        try:
+            with path.open("rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(size - 500_000, 0))
+                text = f.read().decode("utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        file_ts = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+        file_repo = "unknown"
+        hit_len = -1
+        for key, marker in repo_markers.items():
+            if marker and marker in text and len(marker) > hit_len:
+                file_repo = key
+                hit_len = len(marker)
+        for ln in text.splitlines():
+            repo = "unknown"
+            hit_len = -1
+            for key, marker in repo_markers.items():
+                if marker and marker in ln and len(marker) > hit_len:
+                    repo = key
+                    hit_len = len(marker)
+            if repo == "unknown":
+                repo = file_repo
+            ts_m = ISO_TS_RE.search(ln)
+            ts = parse_iso(ts_m.group(0)).isoformat() if ts_m and parse_iso(ts_m.group(0)) else file_ts
+            msg = ""
+            kind = "note"
+
+            bg = BG_DONE_RE.search(ln)
+            if bg:
+                code = int(bg.group("code"))
+                state = "완료" if code == 0 else f"실패({code})"
+                msg = f'Background "{bg.group("label")}" {state}'
+                kind = "background"
+
+            ag = AGENT_DONE_RE.search(ln)
+            if ag:
+                msg = f'Agent "{ag.group("label")}" completed'
+                kind = "agent"
+
+            if not msg and ("PR #" in ln or "pull/" in ln):
+                pr = PR_LINK_RE.search(ln)
+                if pr:
+                    msg = f"PR update: {pr.group(0)}"
+                    kind = "pr"
+
+            if not msg:
+                b = BULLET_NOTE_RE.search(ln)
+                if b:
+                    bmsg = b.group("msg").strip().strip('"')
+                    low = bmsg.lower()
+                    if bmsg.startswith("Background command") or "background" in low:
+                        kind = "background"
+                    elif bmsg.startswith("Agent ") or "agent " in low:
+                        kind = "agent"
+                    elif "pull/" in low or "pr #" in low:
+                        kind = "pr"
+                    elif "lgtm" in low or "review" in low:
+                        kind = "review"
+                    else:
+                        kind = "note"
+                    msg = bmsg[:260]
+
+            if not msg:
+                if "all work" in ln.lower() and "complete" in ln.lower():
+                    msg = "All work complete update"
+                    kind = "summary"
+                elif "lgtm" in ln.lower():
+                    msg = "Review LGTM update"
+                    kind = "review"
+
+            if not msg:
+                continue
+            dedupe = f"{repo}:{kind}:{msg}"
+            if dedupe in seen:
+                continue
+            seen.add(dedupe)
+            rows.append({"repo": repo, "kind": kind, "message": msg, "time": ts, "source": path.name})
+            if len(rows) >= limit:
+                return rows
+
+    rows.sort(key=lambda r: r.get("time", ""), reverse=True)
+    return rows[:limit]
+
+
+def detect_repo_key(text: str, repo_markers: dict[str, str] | None = None) -> str:
+    if repo_markers:
+        hit: str | None = None
+        hit_len = -1
+        for key, marker in repo_markers.items():
+            if marker and marker in text and len(marker) > hit_len:
+                hit = key
+                hit_len = len(marker)
+        if hit:
+            return hit
+    # Check qi2 first because qi1 is a prefix of qi2.
+    if QI2_PATH_RE.search(text):
+        return "qi2"
+    if QI1_PATH_RE.search(text):
+        return "qi1"
+    return "unknown"
+
+
+def score_decay(age_sec: float) -> float:
+    if age_sec <= 120:
+        return 1.0
+    if age_sec <= 600:
+        return 0.6
+    if age_sec <= 1800:
+        return 0.3
+    if age_sec <= 3600:
+        return 0.1
+    return 0.0
+
+
+def infer_runtime_state(
+    now_utc: datetime,
+    score: float,
+    last_event_at: str | None,
+    token_rate_10m: float,
+    waiting_reason: str,
+) -> tuple[str, str]:
+    if waiting_reason in ("rate_limit", "user_reply"):
+        return ("waiting_input", "high")
+    dt = parse_iso(last_event_at)
+    if dt is None:
+        return ("sleeping", "low")
+    age_sec = max(0.0, (now_utc - dt.astimezone(timezone.utc)).total_seconds())
+    if age_sec <= 120 and (score >= 6.0 or token_rate_10m >= 120.0):
+        return ("active", "high")
+    if age_sec <= 600 and score >= 2.0:
+        return ("working", "medium")
+    if age_sec <= 1800 and score >= 1.0:
+        return ("working", "low")
+    if age_sec <= 86400:
+        return ("idle", "low")
+    return ("sleeping", "low")
+
+
+def detect_agent_for_repo_line(text: str, repo_path: Path) -> str | None:
+    lower = text.lower()
+    repo_s = str(repo_path).replace("\\", "/")
+    marker_idx = lower.find(repo_s.lower())
+    if marker_idx < 0:
+        return None
+    rel = lower[marker_idx + len(repo_s) :].lstrip("/")
+    if not rel:
+        return None
+    for agent in AGENTS:
+        for d in agent.dirs:
+            prefix = d.lower().lstrip("/")
+            if rel.startswith(prefix):
+                return agent.agent_id
+    return None
+
+
+def parse_runtime_event_type(line: str) -> tuple[str, int]:
+    if "Bash(" in line:
+        return ("bash", 0)
+    if "Stream started - received first chunk" in line:
+        return ("stream_chunk", 0)
+    if "Query.streamInput" in line:
+        return ("query_input", 0)
+    if MCP_RUNNING_RE.search(line):
+        return ("tool_running", 0)
+    if MCP_DONE_RE.search(line):
+        return ("tool_done", 0)
+    if MCP_FAIL_RE.search(line):
+        return ("tool_failed", 0)
+    m = FORKED_USAGE_RE.search(line)
+    if m:
+        return ("forked_usage", int(m.group("input")) + int(m.group("output")))
+    return ("", 0)
+
+
+def build_token_series(now_utc: datetime, token_events: list[dict[str, Any]]) -> dict[str, Any]:
+    series_1m = [0 for _ in range(30)]
+    for ev in token_events:
+        tok = int(ev.get("token_inc", 0))
+        if tok <= 0:
+            continue
+        ts = parse_iso(str(ev.get("time"))) if ev.get("time") else None
+        if ts is None:
+            continue
+        age_sec = (now_utc - ts.astimezone(timezone.utc)).total_seconds()
+        if age_sec < 0 or age_sec >= 1800:
+            continue
+        idx = int(age_sec // 60)
+        bucket = 29 - idx
+        if 0 <= bucket < 30:
+            series_1m[bucket] += tok
+
+    series_5m = [sum(series_1m[i * 5 : (i + 1) * 5]) for i in range(6)]
+    series_10m = [sum(series_1m[i * 10 : (i + 1) * 10]) for i in range(3)]
+    return {
+        "token_series_1m": series_1m,
+        "token_series_5m": series_5m,
+        "token_series_10m": series_10m,
+        "token_series_updated_at": now_utc.isoformat(),
+    }
+
+
+def parse_runtime_telemetry(now_utc: datetime, repo_map: dict[str, Path], is_limited: bool) -> dict[str, Any]:
+    debug_dir = Path.home() / ".claude" / "debug"
+    repo_markers = {k: str(v).replace("\\", "/") for k, v in repo_map.items()}
+    blank_project = {
+        "active_commands": 0,
+        "last_command": "",
+        "last_seen": None,
+        "observed_tokens": 0,
+        "token_rate_10m": 0.0,
+        "session_total_tokens": 0,
+        "signal": "none",
+        "score": 0.0,
+        "state": "sleeping",
+        "confidence": "low",
+        "last_event_at": None,
+        "last_event_type": "none",
+        "waiting_reason": "none",
+        "evidence": [],
+        "token_series_1m": [0 for _ in range(30)],
+        "token_series_5m": [0 for _ in range(6)],
+        "token_series_10m": [0 for _ in range(3)],
+        "token_series_updated_at": now_utc.isoformat(),
+    }
+    if not debug_dir.exists():
+        return {
+            "projects": {
+                "qi1": dict(blank_project),
+                "qi2": dict(blank_project),
+            },
+            "agents": {"qi1": {}, "qi2": {}},
+            "events": [],
+            "forked_agents": [],
+        }
+
+    files = sorted(
+        [p for p in debug_dir.glob("*.txt") if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:10]
+    project_state = {"qi1": dict(blank_project), "qi2": dict(blank_project)}
+    runtime_agents: dict[str, dict[str, Any]] = {"qi1": {}, "qi2": {}}
+    usage: dict[tuple[str, str], dict[str, Any]] = {}
+    token_10m: dict[str, int] = {"qi1": 0, "qi2": 0}
+    event_rows: list[dict[str, Any]] = []
+
+    for path in files:
+        try:
+            with path.open("rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(size - 350_000, 0))
+                text = f.read().decode("utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        file_repo_key = detect_repo_key(text, repo_markers)
+        lines = text.splitlines()[-2000:]
+
+        for ln in lines:
+            repo_key = detect_repo_key(ln, repo_markers)
+            if repo_key == "unknown":
+                repo_key = file_repo_key
+            if repo_key not in ("qi1", "qi2"):
+                continue
+            ts_m = ISO_TS_RE.search(ln)
+            ts_dt = parse_iso(ts_m.group(0)) if ts_m else None
+            if ts_dt is None:
+                ts_dt = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+            event_type, token_inc = parse_runtime_event_type(ln)
+            if not event_type:
+                continue
+
+            age_sec = max(0.0, (now_utc - ts_dt.astimezone(timezone.utc)).total_seconds())
+            score_gain = EVENT_WEIGHT.get(event_type, 1.0) * score_decay(age_sec)
+            st = project_state[repo_key]
+            st["score"] += score_gain
+            if st["last_event_at"] is None or ts_dt.isoformat() > str(st["last_event_at"]):
+                st["last_event_at"] = ts_dt.isoformat()
+                st["last_event_type"] = event_type
+                st["last_seen"] = ts_dt.isoformat()
+            if len(st["evidence"]) < 3:
+                st["evidence"].append(f"{event_type} · {ts_dt.strftime('%H:%M:%S')} · {ln[:72]}")
+
+            if event_type == "bash":
+                st["active_commands"] += 1 if age_sec <= 600 else 0
+                m = BASH_BLOCK_RE.search(ln)
+                if m:
+                    st["last_command"] = sanitize_command(m.group("cmd"))
+
+            st["session_total_tokens"] += token_inc
+            st["observed_tokens"] += token_inc
+            if age_sec <= 600:
+                token_10m[repo_key] += token_inc
+
+            agent_id = detect_agent_for_repo_line(ln, repo_map[repo_key])
+            if agent_id:
+                bucket = runtime_agents[repo_key].setdefault(
+                    agent_id,
+                    {
+                        "score": 0.0,
+                        "last_event_at": None,
+                        "last_event_type": "none",
+                        "last_command": "",
+                        "active_commands": 0,
+                        "token_10m": 0,
+                        "session_total_tokens": 0,
+                        "evidence": [],
+                    },
+                )
+                bucket["score"] += score_gain
+                bucket["session_total_tokens"] += token_inc
+                if age_sec <= 600:
+                    bucket["token_10m"] += token_inc
+                if event_type == "bash" and age_sec <= 600:
+                    bucket["active_commands"] += 1
+                if event_type == "bash":
+                    m = BASH_BLOCK_RE.search(ln)
+                    if m:
+                        bucket["last_command"] = sanitize_command(m.group("cmd"))
+                if bucket["last_event_at"] is None or ts_dt.isoformat() > str(bucket["last_event_at"]):
+                    bucket["last_event_at"] = ts_dt.isoformat()
+                    bucket["last_event_type"] = event_type
+                if len(bucket["evidence"]) < 2:
+                    bucket["evidence"].append(f"{event_type}@{ts_dt.strftime('%H:%M:%S')}")
+
+            event_rows.append(
+                {
+                    "repo": repo_key,
+                    "agent": agent_id if agent_id else "",
+                    "type": event_type,
+                    "time": ts_dt.isoformat(),
+                    "token_inc": token_inc,
+                }
+            )
+
+        # Forked-agent token usage for grouped display.
+        for ln in lines:
+            m = FORKED_USAGE_RE.search(ln)
+            if not m:
+                continue
+            repo_key = detect_repo_key(ln, repo_markers)
+            if repo_key == "unknown":
+                repo_key = file_repo_key
+            ag = m.group("agent")
+            key = (repo_key, ag)
+            if key not in usage:
+                usage[key] = {
+                    "repo": repo_key,
+                    "agent": ag,
+                    "events": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "last_time": None,
+                }
+            row = usage[key]
+            row["events"] += 1
+            in_tok = int(m.group("input"))
+            out_tok = int(m.group("output"))
+            row["input_tokens"] += in_tok
+            row["output_tokens"] += out_tok
+            ts = parse_iso(m.group("ts"))
+            if ts:
+                cur = parse_iso(row["last_time"]) if row["last_time"] else None
+                if cur is None or ts > cur:
+                    row["last_time"] = ts.isoformat()
+
+    for key in ("qi1", "qi2"):
+        st = project_state[key]
+        series = build_token_series(now_utc, [r for r in event_rows if r.get("repo") == key])
+        st.update(series)
+        st["token_rate_10m"] = float(token_10m[key]) / 10.0
+        waiting_reason = "rate_limit" if is_limited else "none"
+        state, conf = infer_runtime_state(now_utc, float(st["score"]), st["last_event_at"], st["token_rate_10m"], waiting_reason)
+        st["state"] = state
+        st["confidence"] = conf
+        st["waiting_reason"] = waiting_reason
+        if state == "active":
+            st["signal"] = "high"
+        elif state == "working":
+            st["signal"] = "medium"
+        elif state == "waiting_input":
+            st["signal"] = "medium"
+        elif st["last_seen"]:
+            st["signal"] = "low"
+        else:
+            st["signal"] = "none"
+
+        for agent_id, row in runtime_agents[key].items():
+            rate = float(row["token_10m"]) / 10.0
+            a_state, a_conf = infer_runtime_state(now_utc, float(row["score"]), row["last_event_at"], rate, waiting_reason)
+            a_series = build_token_series(
+                now_utc,
+                [r for r in event_rows if r.get("repo") == key and r.get("agent") == agent_id],
+            )
+            row.update(a_series)
+            row["state"] = a_state
+            row["confidence"] = a_conf
+            row["token_rate_10m"] = rate
+            row["waiting_reason"] = waiting_reason
+
+    forked = sorted(
+        usage.values(),
+        key=lambda r: (r["repo"], -(r["input_tokens"] + r["output_tokens"])),
+    )
+    return {"projects": project_state, "agents": runtime_agents, "events": event_rows[-100:], "forked_agents": forked[:20]}
+
+
+def apply_rate_limit_override(status_data: dict[str, Any]) -> None:
+    agents = status_data.get("agents", {})
+    for agent in agents.values():
+        state = agent.get("status", {}).get("state")
+        if state in ("active", "working", "waiting_input"):
+            agent["status"] = {"state": "idle", "label": STATUS_LABEL["idle"], "color": STATUS_COLOR["idle"]}
+
+    summary = {"total_agents": len(AGENTS), "active": 0, "waiting_input": 0, "working": 0, "idle": 0, "sleeping": 0}
+    for agent in agents.values():
+        s = agent.get("status", {}).get("state", "sleeping")
+        if s not in summary:
+            s = "sleeping"
+        summary[s] += 1
+    status_data["summary"] = summary
+
+
+def recalc_summary(status_data: dict[str, Any]) -> None:
+    agents = status_data.get("agents", {})
+    summary = {"total_agents": len(AGENTS), "active": 0, "waiting_input": 0, "working": 0, "idle": 0, "sleeping": 0}
+    for agent in agents.values():
+        s = agent.get("status", {}).get("state", "sleeping")
+        if s not in summary:
+            s = "sleeping"
+        summary[s] += 1
+    status_data["summary"] = summary
+
+
+def enrich_chief_activity(status_data: dict[str, Any], now_utc: datetime, project_name: str, is_limited: bool) -> None:
+    agents = status_data.get("agents", {})
+    chief = agents.get("chief")
+    if not chief:
+        return
+
+    summary = status_data.get("summary", {})
+    waiting_count = int(summary.get("waiting_input", 0))
+    active_count = int(summary.get("active", 0))
+    working_count = int(summary.get("working", 0))
+
+    if is_limited:
+        chief_state = "waiting_input"
+        msg = "Claude limit 감지, 팀 작업을 일시 점검 중"
+    elif waiting_count > 0:
+        chief_state = "waiting_input"
+        msg = f"사용자 응답 대기 {waiting_count}건 확인, 우선순위 정리 중"
+    elif active_count + working_count > 0:
+        chief_state = "active"
+        msg = f"{project_name} 작업자 {active_count + working_count}명 조율 중"
+    else:
+        chief_state = "working"
+        msg = "다음 작업 큐와 리뷰 순서를 정리 중"
+
+    now_iso = now_utc.isoformat()
+    chief["status"] = {"state": chief_state, "label": STATUS_LABEL[chief_state], "color": STATUS_COLOR[chief_state]}
+    chief["last_active"] = now_iso
+    chief["recent_activity"] = [
+        {"hash": "chief", "message": msg, "date": now_iso, "files_changed": 0},
+    ]
+    recalc_summary(status_data)
+
+
+def pick_claude_current_task(projects_payload: list[dict[str, Any]], runtime: dict[str, Any], is_limited: bool) -> str:
+    if is_limited:
+        return "Claude limit 감지, 요청 대기 및 작업 재배치 중"
+
+    runtime_projects = runtime.get("projects", {}) if isinstance(runtime, dict) else {}
+    active_projects: list[tuple[int, str]] = []
+    for proj in projects_payload:
+        pid = str(proj.get("id", ""))
+        rp = runtime_projects.get(pid, {})
+        if str(rp.get("state")) in ("active", "working") and rp.get("last_command"):
+            active_projects.append((int(rp.get("active_commands", 0)), f"{proj.get('name')}: {rp.get('last_command')}"))
+    if active_projects:
+        active_projects.sort(key=lambda x: x[0], reverse=True)
+        return active_projects[0][1]
+
+    candidates: list[str] = []
+    for proj in projects_payload:
+        agents = proj.get("statusData", {}).get("agents", {})
+        chief = agents.get("chief", {})
+        acts = chief.get("recent_activity", [])
+        if acts and acts[0].get("message"):
+            candidates.append(str(acts[0]["message"]))
+
+    if not candidates:
+        return "진행 중인 조율 작업 없음"
+
+    waiting = [msg for msg in candidates if "응답 대기" in msg]
+    if waiting:
+        return waiting[0]
+    return candidates[0]
+
+
+def build_agent_status(repo: Path, now_utc: datetime, runtime_agent_map: dict[str, Any], project_runtime: dict[str, Any]) -> dict[str, Any]:
+    agents: dict[str, Any] = {}
+    summary = {"total_agents": len(AGENTS), "active": 0, "waiting_input": 0, "working": 0, "idle": 0, "sleeping": 0}
+
+    for agent in AGENTS:
+        c7 = count_commits(repo, 7, agent.dirs)
+        c30 = count_commits(repo, 30, agent.dirs)
+        files = tracked_files(repo, agent.dirs)
+        last = last_active(repo, agent.dirs)
+        dirty = has_uncommitted_changes(repo, agent.dirs)
+        runtime_row = runtime_agent_map.get(agent.agent_id, {})
+        runtime_state = runtime_row.get("state")
+
+        if runtime_state in STATUS_LABEL:
+            state = str(runtime_state)
+            source = "runtime"
+        elif dirty:
+            state = "working"
+            source = "dirty"
+        else:
+            proj_state = str(project_runtime.get("state", "idle"))
+            state = "idle" if proj_state in ("active", "working", "waiting_input") else "sleeping"
+            source = "fallback"
+
+        summary[state] += 1
+
+        runtime_status = {
+            "state": runtime_row.get("state", state),
+            "confidence": runtime_row.get("confidence", "low"),
+            "score": float(runtime_row.get("score", 0.0)),
+            "last_signal_at": runtime_row.get("last_event_at"),
+            "last_event_type": runtime_row.get("last_event_type", "none"),
+            "last_command": runtime_row.get("last_command", ""),
+            "token_rate_10m": float(runtime_row.get("token_rate_10m", 0.0)),
+            "session_total_tokens": int(runtime_row.get("session_total_tokens", 0)),
+            "active_command_count": int(runtime_row.get("active_commands", 0)),
+            "waiting_reason": runtime_row.get("waiting_reason", "none"),
+            "evidence": runtime_row.get("evidence", []),
+            "token_series_1m": runtime_row.get("token_series_1m", [0 for _ in range(30)]),
+            "token_series_5m": runtime_row.get("token_series_5m", [0 for _ in range(6)]),
+            "token_series_10m": runtime_row.get("token_series_10m", [0 for _ in range(3)]),
+            "token_series_updated_at": runtime_row.get("token_series_updated_at"),
+            "source": source,
+        }
+
+        agents[agent.agent_id] = {
+            "status": {"state": state, "label": STATUS_LABEL[state], "color": STATUS_COLOR[state]},
+            "runtime_status": runtime_status,
+            "stats": {
+                "commits_7d": c7,
+                "commits_30d": c30,
+                "files_tracked": files,
+                "dirty": dirty,
+                "tokens_10m": runtime_status["token_rate_10m"],
+                "tokens_session": runtime_status["session_total_tokens"],
+            },
+            "last_active": last,
+            "recent_activity": recent_activity(repo, agent.dirs, limit=2),
+        }
+
+    return {"agents": agents, "summary": summary}
+
+
+def build_payload(repo_map: dict[str, Path]) -> dict[str, Any]:
+    now_utc = datetime.now(timezone.utc)
+    rate_limit = detect_claude_rate_limit(now_utc)
+    claude_code = detect_claude_code_state(now_utc, rate_limit["is_limited"])
+    recent_commands = parse_recent_commands(now_utc, limit=10)
+    recent_notes = parse_recent_runtime_notes(now_utc, repo_map, limit=12)
+    runtime = parse_runtime_telemetry(now_utc, repo_map, rate_limit["is_limited"])
+    projects_payload: list[dict[str, Any]] = []
+
+    for proj in PROJECTS:
+        proj_id = str(proj["id"])
+        repo = repo_map[proj["id"]]
+        runtime_agents = runtime.get("agents", {}).get(proj_id, {})
+        runtime_project = runtime.get("projects", {}).get(proj_id, {})
+        status_data = build_agent_status(repo, now_utc, runtime_agents, runtime_project)
+        enrich_chief_activity(status_data, now_utc, proj["name"], rate_limit["is_limited"])
+        status_data["generated_at"] = now_utc.isoformat()
+        status_data["project_runtime"] = runtime_project
+        projects_payload.append(
+            {
+                "id": proj["id"],
+                "name": proj["name"],
+                "roomName": proj["roomName"],
+                "color": proj["color"],
+                "bgColor": proj["bgColor"],
+                "branch": branch_name(repo),
+                "statusData": status_data,
+            }
+        )
+
+    claude_code["current_task"] = pick_claude_current_task(projects_payload, runtime, rate_limit["is_limited"])
+
+    return {
+        "generated_at": now_utc.isoformat(),
+        "projects": projects_payload,
+        "claude_limit": rate_limit,
+        "claude_code": claude_code,
+        "recent_commands": recent_commands,
+        "recent_notes": recent_notes,
+        "runtime": runtime,
+    }
+
+
+def make_handler(html_path: Path, repo_map: dict[str, Path]):
+    assets_root = html_path.parent / "assets"
+
+    def content_type_for(path: Path) -> str:
+        ext = path.suffix.lower()
+        if ext == ".svg":
+            return "image/svg+xml"
+        if ext == ".ico":
+            return "image/x-icon"
+        if ext == ".png":
+            return "image/png"
+        if ext == ".js":
+            return "application/javascript; charset=utf-8"
+        if ext == ".css":
+            return "text/css; charset=utf-8"
+        return "application/octet-stream"
+
+    class Handler(BaseHTTPRequestHandler):
+        def _send(self, code: int, body: bytes, content_type: str) -> None:
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802
+            path = urlparse(self.path).path
+            if path in ("/", "/index.html"):
+                try:
+                    html = html_path.read_bytes()
+                except OSError as exc:
+                    self._send(500, f"Failed to read HTML: {exc}".encode(), "text/plain; charset=utf-8")
+                    return
+                self._send(200, html, "text/html; charset=utf-8")
+                return
+
+            if path.startswith("/assets/"):
+                rel = path[len("/assets/") :]
+                target = (assets_root / rel).resolve()
+                try:
+                    target.relative_to(assets_root.resolve())
+                except ValueError:
+                    self._send(403, b"Forbidden", "text/plain; charset=utf-8")
+                    return
+                if not target.exists() or not target.is_file():
+                    self._send(404, b"Not Found", "text/plain; charset=utf-8")
+                    return
+                try:
+                    body = target.read_bytes()
+                except OSError as exc:
+                    self._send(500, f"Failed to read asset: {exc}".encode(), "text/plain; charset=utf-8")
+                    return
+                self._send(200, body, content_type_for(target))
+                return
+
+            if path == "/api/agent-office/status":
+                payload = build_payload(repo_map)
+                self._send(
+                    200,
+                    json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                    "application/json; charset=utf-8",
+                )
+                return
+
+            self._send(404, b"Not Found", "text/plain; charset=utf-8")
+
+        def log_message(self, fmt: str, *args: Any) -> None:
+            return
+
+    return Handler
+
+
+def main() -> None:
+    script_dir = Path(__file__).resolve().parent
+    default_tools_root = script_dir.parent
+    default_quant_root = default_tools_root.parent
+
+    html_candidates = (
+        default_tools_root / "quant-desktop-live.html",
+        default_quant_root / "quant-desktop-live.html",
+    )
+    default_html = next((p for p in html_candidates if p.exists()), html_candidates[0])
+
+    parser = argparse.ArgumentParser(description="Serve Quant Agent Office with live git status.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument(
+        "--html",
+        default=str(default_html),
+        help="Path to quant-desktop-live.html",
+    )
+    parser.add_argument(
+        "--qi1-repo",
+        default=str(default_quant_root / "quant-investment"),
+        help="Path to quant-investment repo",
+    )
+    parser.add_argument(
+        "--qi2-repo",
+        default=str(default_tools_root),
+        help="Path to quant-investment2 repo",
+    )
+    args = parser.parse_args()
+
+    html_path = Path(args.html).resolve()
+    repo_map = {
+        "qi1": Path(args.qi1_repo).resolve(),
+        "qi2": Path(args.qi2_repo).resolve(),
+    }
+    for repo in repo_map.values():
+        if not (repo / ".git").exists():
+            raise SystemExit(f"Not a git repo: {repo}")
+    if not html_path.exists():
+        raise SystemExit(f"HTML file not found: {html_path}")
+
+    server = ThreadingHTTPServer((args.host, args.port), make_handler(html_path, repo_map))
+    print(f"Serving Agent Office at http://{args.host}:{args.port}")
+    print(f"HTML: {html_path}")
+    print(f"API:  http://{args.host}:{args.port}/api/agent-office/status")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+"""API package for Agent Task Tracking."""
+

--- a/api/database.py
+++ b/api/database.py
@@ -15,6 +15,9 @@ Base = declarative_base()
 
 # Register models here so metadata has all tables.
 import api.models.agent_task  # noqa: F401,E402
+import api.models.agent_task_edge  # noqa: F401,E402
+import api.models.agent_chat  # noqa: F401,E402
+import api.models.agent_presence  # noqa: F401,E402
 
 
 def get_db() -> Generator:
@@ -27,4 +30,3 @@ def get_db() -> Generator:
 
 def init_db() -> None:
     Base.metadata.create_all(bind=engine)
-

--- a/api/database.py
+++ b/api/database.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./agent_tasks.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+Base = declarative_base()
+
+# Register models here so metadata has all tables.
+import api.models.agent_task  # noqa: F401,E402
+
+
+def get_db() -> Generator:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.websockets import WebSocket, WebSocketDisconnect
 
 from api.database import init_db
-from api.routers import agent_task_router
+from api.realtime import realtime_hub
+from api.routers import (
+    agent_chat_router,
+    agent_graph_router,
+    agent_presence_router,
+    agent_task_router,
+)
 
 app = FastAPI(title="Agent Task Tracking API", version="0.1.0")
 app.include_router(agent_task_router)
+app.include_router(agent_chat_router)
+app.include_router(agent_graph_router)
+app.include_router(agent_presence_router)
 
 
 @app.on_event("startup")
@@ -18,3 +31,21 @@ def on_startup() -> None:
 def health() -> dict[str, str]:
     return {"status": "ok"}
 
+
+@app.get("/ui")
+def office_ui() -> FileResponse:
+    html = Path(__file__).resolve().parent / "static" / "office.html"
+    return FileResponse(str(html))
+
+
+@app.websocket("/ws/office")
+async def office_ws(websocket: WebSocket) -> None:
+    await realtime_hub.connect(websocket)
+    try:
+        while True:
+            # Keep alive: client may send any ping payload.
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        realtime_hub.disconnect(websocket)
+    except Exception:
+        realtime_hub.disconnect(websocket)

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from api.database import init_db
+from api.routers import agent_task_router
+
+app = FastAPI(title="Agent Task Tracking API", version="0.1.0")
+app.include_router(agent_task_router)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+

--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ from api.routers import (
     agent_graph_router,
     agent_presence_router,
     agent_task_router,
+    integrations_router,
 )
 
 app = FastAPI(title="Agent Task Tracking API", version="0.1.0")
@@ -20,6 +21,7 @@ app.include_router(agent_task_router)
 app.include_router(agent_chat_router)
 app.include_router(agent_graph_router)
 app.include_router(agent_presence_router)
+app.include_router(integrations_router)
 
 
 @app.on_event("startup")

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,0 +1,2 @@
+"""SQLAlchemy models."""
+

--- a/api/models/agent_chat.py
+++ b/api/models/agent_chat.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import JSON as SAJSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from api.database import Base
+
+
+class AgentChatRoom(Base):
+    __tablename__ = "agent_chat_rooms"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    room_key: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    room_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class AgentChatMessage(Base):
+    __tablename__ = "agent_chat_messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    room_id: Mapped[int] = mapped_column(Integer, ForeignKey("agent_chat_rooms.id"), index=True, nullable=False)
+    sender_type: Mapped[str] = mapped_column(String(32), nullable=False, default="agent")
+    sender_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    session_id: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
+    team_name: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[dict] = mapped_column(SAJSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+

--- a/api/models/agent_presence.py
+++ b/api/models/agent_presence.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from api.database import Base
+
+
+class AgentPresence(Base):
+    __tablename__ = "agent_presence"
+    __table_args__ = (UniqueConstraint("agent_name", name="uq_agent_presence_name"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    agent_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    agent_name: Mapped[str] = mapped_column(String(128), index=True, nullable=False)
+    session_id: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
+    team_name: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
+    state: Mapped[str] = mapped_column(String(32), nullable=False, default="idle")
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+

--- a/api/models/agent_task.py
+++ b/api/models/agent_task.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String, Text, func
+from sqlalchemy import JSON as SAJSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from api.database import Base
+
+
+class AgentTask(Base):
+    __tablename__ = "agent_tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    task_id: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    session_id: Mapped[str | None] = mapped_column(String(128), index=True, nullable=True)
+    agent_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    team_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    subject: Mapped[str] = mapped_column(String(512), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="pending")
+    files_modified: Mapped[list[str]] = mapped_column(SAJSON, nullable=False, default=list)
+    metadata_json: Mapped[dict] = mapped_column(SAJSON, nullable=False, default=dict)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    def mark_timestamps_from_status(self, status: str) -> None:
+        now = datetime.now(timezone.utc)
+        if status == "in_progress" and self.started_at is None:
+            self.started_at = now
+        if status == "completed":
+            if self.started_at is None:
+                self.started_at = now
+            if self.completed_at is None:
+                self.completed_at = now
+

--- a/api/models/agent_task_edge.py
+++ b/api/models/agent_task_edge.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from api.database import Base
+
+
+class AgentTaskEdge(Base):
+    __tablename__ = "agent_task_edges"
+    __table_args__ = (
+        UniqueConstraint("parent_task_id", "child_task_id", "edge_type", name="uq_task_edge"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    parent_task_id: Mapped[str] = mapped_column(String(64), index=True, nullable=False)
+    child_task_id: Mapped[str] = mapped_column(String(64), index=True, nullable=False)
+    edge_type: Mapped[str] = mapped_column(String(32), nullable=False, default="spawned")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+

--- a/api/realtime.py
+++ b/api/realtime.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import WebSocket
+
+
+class RealtimeHub:
+    def __init__(self) -> None:
+        self._clients: set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self._clients.add(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self._clients.discard(websocket)
+
+    async def broadcast(self, event_type: str, data: dict[str, Any]) -> None:
+        if not self._clients:
+            return
+        payload = json.dumps(
+            {
+                "event_type": event_type,
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "data": data,
+            },
+            ensure_ascii=False,
+        )
+        dead: list[WebSocket] = []
+        for ws in self._clients:
+            try:
+                await ws.send_text(payload)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self._clients.discard(ws)
+
+
+realtime_hub = RealtimeHub()
+

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,0 +1,4 @@
+from api.routers.agent_task import router as agent_task_router
+
+__all__ = ["agent_task_router"]
+

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -2,10 +2,12 @@ from api.routers.agent_task import router as agent_task_router
 from api.routers.agent_chat import router as agent_chat_router
 from api.routers.agent_graph import router as agent_graph_router
 from api.routers.agent_presence import router as agent_presence_router
+from api.routers.integrations import router as integrations_router
 
 __all__ = [
     "agent_task_router",
     "agent_chat_router",
     "agent_graph_router",
     "agent_presence_router",
+    "integrations_router",
 ]

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,4 +1,11 @@
 from api.routers.agent_task import router as agent_task_router
+from api.routers.agent_chat import router as agent_chat_router
+from api.routers.agent_graph import router as agent_graph_router
+from api.routers.agent_presence import router as agent_presence_router
 
-__all__ = ["agent_task_router"]
-
+__all__ = [
+    "agent_task_router",
+    "agent_chat_router",
+    "agent_graph_router",
+    "agent_presence_router",
+]

--- a/api/routers/agent_chat.py
+++ b/api/routers/agent_chat.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from api.realtime import realtime_hub
+from api.schemas.agent_chat import (
+    ChatMessageCreateRequest,
+    ChatMessageResponse,
+    ChatRoomCreateRequest,
+    ChatRoomResponse,
+)
+from api.services.agent_chat_service import agent_chat_service
+
+router = APIRouter(prefix="/api/agent-chat", tags=["agent-chat"])
+
+
+@router.post("/rooms", response_model=ChatRoomResponse)
+def create_room(payload: ChatRoomCreateRequest) -> ChatRoomResponse:
+    room = agent_chat_service.create_room(payload)
+    return ChatRoomResponse.model_validate(room)
+
+
+@router.get("/rooms", response_model=list[ChatRoomResponse])
+def list_rooms() -> list[ChatRoomResponse]:
+    rooms = agent_chat_service.list_rooms()
+    return [ChatRoomResponse.model_validate(r) for r in rooms]
+
+
+@router.post("/messages", response_model=ChatMessageResponse)
+async def create_message(payload: ChatMessageCreateRequest) -> ChatMessageResponse:
+    msg = agent_chat_service.create_message(
+        room_key=payload.room_key,
+        sender_type=payload.sender_type,
+        sender_name=payload.sender_name,
+        session_id=payload.session_id,
+        team_name=payload.team_name,
+        message=payload.message,
+        metadata_json=payload.metadata_json,
+    )
+    response = ChatMessageResponse.model_validate(msg)
+    await realtime_hub.broadcast("chat.message.created", response.model_dump(mode="json"))
+    return response
+
+
+@router.get("/messages", response_model=list[ChatMessageResponse])
+def list_messages(room_key: str = Query(...), limit: int = Query(default=50, ge=1, le=200)) -> list[ChatMessageResponse]:
+    rows = agent_chat_service.list_messages(room_key=room_key, limit=limit)
+    return [ChatMessageResponse.model_validate(r) for r in rows]
+

--- a/api/routers/agent_graph.py
+++ b/api/routers/agent_graph.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from api.schemas.agent_graph import GraphResponse
+from api.services.agent_graph_service import agent_graph_service
+
+router = APIRouter(prefix="/api/agent-graph", tags=["agent-graph"])
+
+
+@router.get("", response_model=GraphResponse)
+def get_graph(
+    session_id: str | None = Query(default=None),
+    team_name: str | None = Query(default=None),
+) -> GraphResponse:
+    nodes, edges = agent_graph_service.get_graph(session_id=session_id, team_name=team_name)
+    return GraphResponse(nodes=nodes, edges=edges)
+

--- a/api/routers/agent_presence.py
+++ b/api/routers/agent_presence.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from api.realtime import realtime_hub
+from api.schemas.agent_presence import PresenceResponse, PresenceUpsertRequest
+from api.services.agent_presence_service import agent_presence_service
+
+router = APIRouter(prefix="/api/agent-presence", tags=["agent-presence"])
+
+
+@router.get("", response_model=list[PresenceResponse])
+def list_presence() -> list[PresenceResponse]:
+    rows = agent_presence_service.list()
+    return [PresenceResponse.model_validate(r) for r in rows]
+
+
+@router.post("", response_model=PresenceResponse)
+async def upsert_presence(payload: PresenceUpsertRequest) -> PresenceResponse:
+    row = agent_presence_service.upsert(payload)
+    response = PresenceResponse.model_validate(row)
+    await realtime_hub.broadcast("presence.updated", response.model_dump(mode="json"))
+    return response
+

--- a/api/routers/agent_task.py
+++ b/api/routers/agent_task.py
@@ -8,25 +8,45 @@ from api.schemas.agent_task import (
     AgentTaskResponse,
     AgentTaskUpdateRequest,
 )
+from api.services.agent_chat_service import agent_chat_service
+from api.services.agent_graph_service import agent_graph_service
 from api.services.agent_task_service import agent_task_service
+from api.realtime import realtime_hub
 
 router = APIRouter(prefix="/api/agent-tasks", tags=["agent-tasks"])
 
 
 @router.post("", response_model=AgentTaskResponse)
-def create_agent_task(payload: AgentTaskCreateRequest) -> AgentTaskResponse:
+async def create_agent_task(payload: AgentTaskCreateRequest) -> AgentTaskResponse:
     task = agent_task_service.create_task(payload)
-    return AgentTaskResponse.model_validate(task)
+    if payload.parent_task_id:
+        agent_graph_service.add_edge(payload.parent_task_id, payload.task_id, "spawned")
+    agent_chat_service.create_message(
+        room_key=payload.team_name or "general",
+        sender_type="system",
+        sender_name="task-bot",
+        session_id=payload.session_id,
+        team_name=payload.team_name,
+        message=f"Task created: {payload.task_id} - {payload.subject}",
+        metadata_json={"event": "task.created"},
+    )
+    response = AgentTaskResponse.model_validate(task)
+    await realtime_hub.broadcast("task.created", response.model_dump(mode="json"))
+    return response
 
 
 @router.put("/{task_id}", response_model=AgentTaskResponse)
-def update_agent_task(task_id: str, payload: AgentTaskUpdateRequest) -> AgentTaskResponse:
+async def update_agent_task(task_id: str, payload: AgentTaskUpdateRequest) -> AgentTaskResponse:
     if payload.task_id != task_id:
         raise HTTPException(status_code=400, detail="task_id in body must match path")
     task = agent_task_service.update_task(task_id, payload)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
-    return AgentTaskResponse.model_validate(task)
+    if payload.parent_task_id:
+        agent_graph_service.add_edge(payload.parent_task_id, payload.task_id, "related")
+    response = AgentTaskResponse.model_validate(task)
+    await realtime_hub.broadcast("task.updated", response.model_dump(mode="json"))
+    return response
 
 
 @router.get("", response_model=AgentTaskListResponse)
@@ -63,4 +83,3 @@ def delete_agent_task(task_id: str) -> dict[str, bool]:
     if not deleted:
         raise HTTPException(status_code=404, detail="Task not found")
     return {"deleted": True}
-

--- a/api/routers/agent_task.py
+++ b/api/routers/agent_task.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+
+from api.schemas.agent_task import (
+    AgentTaskCreateRequest,
+    AgentTaskListResponse,
+    AgentTaskResponse,
+    AgentTaskUpdateRequest,
+)
+from api.services.agent_task_service import agent_task_service
+
+router = APIRouter(prefix="/api/agent-tasks", tags=["agent-tasks"])
+
+
+@router.post("", response_model=AgentTaskResponse)
+def create_agent_task(payload: AgentTaskCreateRequest) -> AgentTaskResponse:
+    task = agent_task_service.create_task(payload)
+    return AgentTaskResponse.model_validate(task)
+
+
+@router.put("/{task_id}", response_model=AgentTaskResponse)
+def update_agent_task(task_id: str, payload: AgentTaskUpdateRequest) -> AgentTaskResponse:
+    if payload.task_id != task_id:
+        raise HTTPException(status_code=400, detail="task_id in body must match path")
+    task = agent_task_service.update_task(task_id, payload)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return AgentTaskResponse.model_validate(task)
+
+
+@router.get("", response_model=AgentTaskListResponse)
+def list_agent_tasks(
+    status: str | None = Query(default=None),
+    agent_type: str | None = Query(default=None),
+    session_id: str | None = Query(default=None),
+    team_name: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> AgentTaskListResponse:
+    tasks, total = agent_task_service.list_tasks(
+        status=status,
+        agent_type=agent_type,
+        session_id=session_id,
+        team_name=team_name,
+        limit=limit,
+        offset=offset,
+    )
+    return AgentTaskListResponse(tasks=[AgentTaskResponse.model_validate(t) for t in tasks], total_count=total)
+
+
+@router.get("/{task_id}", response_model=AgentTaskResponse)
+def get_agent_task(task_id: str) -> AgentTaskResponse:
+    task = agent_task_service.get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return AgentTaskResponse.model_validate(task)
+
+
+@router.delete("/{task_id}")
+def delete_agent_task(task_id: str) -> dict[str, bool]:
+    deleted = agent_task_service.delete_task(task_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return {"deleted": True}
+

--- a/api/routers/integrations.py
+++ b/api/routers/integrations.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from fastapi import APIRouter, HTTPException
+
+from api.realtime import realtime_hub
+from api.services.agent_office_sync_service import agent_office_sync_service
+
+router = APIRouter(prefix="/api/integrations", tags=["integrations"])
+
+
+class SyncAgentOfficeRequest(BaseModel):
+    source_url: str | None = Field(default=None)
+
+
+@router.post("/agent-office/sync")
+async def sync_agent_office(payload: SyncAgentOfficeRequest) -> dict:
+    try:
+        result = agent_office_sync_service.sync(payload.source_url)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"sync failed: {exc}") from exc
+
+    response = {
+        "source_url": result.source_url,
+        "projects": result.projects,
+        "agents_seen": result.agents_seen,
+        "presence_upserts": result.presence_upserts,
+        "chat_messages": result.chat_messages,
+    }
+    await realtime_hub.broadcast("integration.agent_office.synced", response)
+    return response
+

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -1,0 +1,2 @@
+"""Pydantic schemas."""
+

--- a/api/schemas/agent_chat.py
+++ b/api/schemas/agent_chat.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SenderType = Literal["user", "agent", "system"]
+
+
+class ChatRoomCreateRequest(BaseModel):
+    room_key: str = Field(min_length=1, max_length=64)
+    room_name: str = Field(min_length=1, max_length=128)
+
+
+class ChatRoomResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    room_key: str
+    room_name: str
+    created_at: datetime
+
+
+class ChatMessageCreateRequest(BaseModel):
+    room_key: str = Field(min_length=1, max_length=64)
+    sender_type: SenderType = "agent"
+    sender_name: str = Field(min_length=1, max_length=128)
+    session_id: str | None = Field(default=None, max_length=128)
+    team_name: str | None = Field(default=None, max_length=128)
+    message: str = Field(min_length=1)
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatMessageResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    room_id: int
+    sender_type: SenderType
+    sender_name: str
+    session_id: str | None
+    team_name: str | None
+    message: str
+    metadata_json: dict[str, Any]
+    created_at: datetime
+

--- a/api/schemas/agent_graph.py
+++ b/api/schemas/agent_graph.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class GraphNode(BaseModel):
+    id: str
+    label: str
+    status: str
+    agent_type: str | None
+    team_name: str | None
+    session_id: str | None
+    metadata: dict[str, Any]
+
+
+class GraphEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    edge_type: str
+
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+

--- a/api/schemas/agent_presence.py
+++ b/api/schemas/agent_presence.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PresenceState = Literal["active", "idle", "offline"]
+
+
+class PresenceUpsertRequest(BaseModel):
+    agent_name: str = Field(min_length=1, max_length=128)
+    agent_type: str | None = Field(default=None, max_length=64)
+    session_id: str | None = Field(default=None, max_length=128)
+    team_name: str | None = Field(default=None, max_length=128)
+    state: PresenceState = "active"
+
+
+class PresenceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    agent_name: str
+    agent_type: str | None
+    session_id: str | None
+    team_name: str | None
+    state: PresenceState
+    last_seen_at: datetime
+

--- a/api/schemas/agent_task.py
+++ b/api/schemas/agent_task.py
@@ -17,6 +17,7 @@ class AgentTaskCreateRequest(BaseModel):
     description: str | None = None
     status: TaskStatus = "pending"
     metadata_json: dict[str, Any] = Field(default_factory=dict)
+    parent_task_id: str | None = Field(default=None, max_length=64)
 
 
 class AgentTaskUpdateRequest(BaseModel):
@@ -27,6 +28,7 @@ class AgentTaskUpdateRequest(BaseModel):
     description: str | None = None
     files_modified: list[str] | None = None
     metadata_json: dict[str, Any] | None = None
+    parent_task_id: str | None = Field(default=None, max_length=64)
 
 
 class AgentTaskResponse(BaseModel):
@@ -51,4 +53,3 @@ class AgentTaskResponse(BaseModel):
 class AgentTaskListResponse(BaseModel):
     tasks: list[AgentTaskResponse]
     total_count: int
-

--- a/api/schemas/agent_task.py
+++ b/api/schemas/agent_task.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TaskStatus = Literal["pending", "in_progress", "completed", "deleted"]
+
+
+class AgentTaskCreateRequest(BaseModel):
+    task_id: str = Field(min_length=1, max_length=64)
+    session_id: str | None = Field(default=None, max_length=128)
+    agent_type: str | None = Field(default=None, max_length=64)
+    team_name: str | None = Field(default=None, max_length=128)
+    subject: str = Field(min_length=1, max_length=512)
+    description: str | None = None
+    status: TaskStatus = "pending"
+    metadata_json: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentTaskUpdateRequest(BaseModel):
+    task_id: str = Field(min_length=1, max_length=64)
+    session_id: str | None = Field(default=None, max_length=128)
+    status: TaskStatus | None = None
+    subject: str | None = Field(default=None, max_length=512)
+    description: str | None = None
+    files_modified: list[str] | None = None
+    metadata_json: dict[str, Any] | None = None
+
+
+class AgentTaskResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    task_id: str
+    session_id: str | None
+    agent_type: str | None
+    team_name: str | None
+    subject: str
+    description: str | None
+    status: TaskStatus
+    files_modified: list[str]
+    metadata_json: dict[str, Any]
+    started_at: datetime | None
+    completed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentTaskListResponse(BaseModel):
+    tasks: list[AgentTaskResponse]
+    total_count: int
+

--- a/api/services/__init__.py
+++ b/api/services/__init__.py
@@ -1,0 +1,2 @@
+"""Service layer."""
+

--- a/api/services/agent_chat_service.py
+++ b/api/services/agent_chat_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from api.database import SessionLocal
+from api.models.agent_chat import AgentChatMessage, AgentChatRoom
+from api.schemas.agent_chat import ChatMessageCreateRequest, ChatRoomCreateRequest
+
+
+class AgentChatService:
+    def __init__(self, session_factory: Callable[[], Session] = SessionLocal) -> None:
+        self._session_factory = session_factory
+
+    def ensure_room(self, room_key: str, room_name: str | None = None) -> AgentChatRoom:
+        with self._session_factory() as db:
+            room = db.scalar(select(AgentChatRoom).where(AgentChatRoom.room_key == room_key))
+            if room:
+                return room
+            room = AgentChatRoom(room_key=room_key, room_name=room_name or room_key)
+            db.add(room)
+            db.commit()
+            db.refresh(room)
+            return room
+
+    def create_room(self, payload: ChatRoomCreateRequest) -> AgentChatRoom:
+        return self.ensure_room(payload.room_key, payload.room_name)
+
+    def list_rooms(self) -> list[AgentChatRoom]:
+        with self._session_factory() as db:
+            return list(db.scalars(select(AgentChatRoom).order_by(AgentChatRoom.room_key.asc())).all())
+
+    def create_message(
+        self,
+        *,
+        room_key: str,
+        sender_type: str,
+        sender_name: str,
+        session_id: str | None,
+        team_name: str | None,
+        message: str,
+        metadata_json: dict | None = None,
+    ) -> AgentChatMessage:
+        payload = ChatMessageCreateRequest(
+            room_key=room_key,
+            sender_type=sender_type,
+            sender_name=sender_name,
+            session_id=session_id,
+            team_name=team_name,
+            message=message,
+            metadata_json=metadata_json or {},
+        )
+        with self._session_factory() as db:
+            room = db.scalar(select(AgentChatRoom).where(AgentChatRoom.room_key == payload.room_key))
+            if room is None:
+                room = AgentChatRoom(room_key=payload.room_key, room_name=payload.room_key)
+                db.add(room)
+                db.flush()
+
+            row = AgentChatMessage(
+                room_id=room.id,
+                sender_type=payload.sender_type,
+                sender_name=payload.sender_name,
+                session_id=payload.session_id,
+                team_name=payload.team_name,
+                message=payload.message,
+                metadata_json=payload.metadata_json or {},
+            )
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            return row
+
+    def list_messages(self, room_key: str, limit: int = 50) -> list[AgentChatMessage]:
+        with self._session_factory() as db:
+            room = db.scalar(select(AgentChatRoom).where(AgentChatRoom.room_key == room_key))
+            if room is None:
+                return []
+            query = (
+                select(AgentChatMessage)
+                .where(AgentChatMessage.room_id == room.id)
+                .order_by(AgentChatMessage.created_at.desc())
+                .limit(limit)
+            )
+            rows = list(db.scalars(query).all())
+            rows.reverse()
+            return rows
+
+
+agent_chat_service = AgentChatService()

--- a/api/services/agent_graph_service.py
+++ b/api/services/agent_graph_service.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from api.database import SessionLocal
+from api.models.agent_task import AgentTask
+from api.models.agent_task_edge import AgentTaskEdge
+from api.schemas.agent_graph import GraphEdge, GraphNode
+
+
+class AgentGraphService:
+    def __init__(self, session_factory: Callable[[], Session] = SessionLocal) -> None:
+        self._session_factory = session_factory
+
+    def add_edge(self, parent_task_id: str, child_task_id: str, edge_type: str = "spawned") -> AgentTaskEdge | None:
+        if not parent_task_id or not child_task_id or parent_task_id == child_task_id:
+            return None
+        with self._session_factory() as db:
+            exists = db.scalar(
+                select(AgentTaskEdge).where(
+                    AgentTaskEdge.parent_task_id == parent_task_id,
+                    AgentTaskEdge.child_task_id == child_task_id,
+                    AgentTaskEdge.edge_type == edge_type,
+                )
+            )
+            if exists:
+                return exists
+            row = AgentTaskEdge(parent_task_id=parent_task_id, child_task_id=child_task_id, edge_type=edge_type)
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            return row
+
+    def get_graph(self, session_id: str | None = None, team_name: str | None = None) -> tuple[list[GraphNode], list[GraphEdge]]:
+        with self._session_factory() as db:
+            task_query = select(AgentTask)
+            if session_id:
+                task_query = task_query.where(AgentTask.session_id == session_id)
+            if team_name:
+                task_query = task_query.where(AgentTask.team_name == team_name)
+            tasks = list(db.scalars(task_query).all())
+            task_ids = {t.task_id for t in tasks}
+
+            edge_query = select(AgentTaskEdge)
+            edges_raw = list(db.scalars(edge_query).all())
+            edges = [
+                e
+                for e in edges_raw
+                if (not task_ids or (e.parent_task_id in task_ids or e.child_task_id in task_ids))
+            ]
+
+            nodes = [
+                GraphNode(
+                    id=t.task_id,
+                    label=t.subject,
+                    status=t.status,
+                    agent_type=t.agent_type,
+                    team_name=t.team_name,
+                    session_id=t.session_id,
+                    metadata=t.metadata_json or {},
+                )
+                for t in tasks
+            ]
+            graph_edges = [
+                GraphEdge(
+                    id=f"{e.parent_task_id}->{e.child_task_id}:{e.edge_type}",
+                    source=e.parent_task_id,
+                    target=e.child_task_id,
+                    edge_type=e.edge_type,
+                )
+                for e in edges
+            ]
+            return nodes, graph_edges
+
+
+agent_graph_service = AgentGraphService()
+

--- a/api/services/agent_office_sync_service.py
+++ b/api/services/agent_office_sync_service.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.request import Request, urlopen
+
+from api.services.agent_chat_service import agent_chat_service
+from api.services.agent_presence_service import agent_presence_service
+from api.schemas.agent_presence import PresenceUpsertRequest
+
+DEFAULT_AGENT_OFFICE_STATUS_URL = os.getenv(
+    "AGENT_OFFICE_STATUS_URL",
+    "http://127.0.0.1:8766/api/agent-office/status",
+)
+
+
+@dataclass
+class SyncResult:
+    source_url: str
+    projects: int
+    agents_seen: int
+    presence_upserts: int
+    chat_messages: int
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    req = Request(url, headers={"Accept": "application/json"})
+    with urlopen(req, timeout=5) as res:
+        body = res.read().decode("utf-8", errors="ignore")
+    data = json.loads(body)
+    return data if isinstance(data, dict) else {}
+
+
+def _map_presence_state(raw: str) -> str:
+    if raw in ("active", "working"):
+        return "active"
+    if raw in ("waiting_input", "idle"):
+        return "idle"
+    return "offline"
+
+
+class AgentOfficeSyncService:
+    def sync(self, source_url: str | None = None) -> SyncResult:
+        url = source_url or DEFAULT_AGENT_OFFICE_STATUS_URL
+        payload = _fetch_json(url)
+        projects = payload.get("projects", [])
+
+        agents_seen = 0
+        presence_upserts = 0
+        chat_messages = 0
+
+        for proj in projects:
+            proj_name = str(proj.get("name") or proj.get("id") or "unknown")
+            status_data = proj.get("statusData", {}) if isinstance(proj, dict) else {}
+            agents = status_data.get("agents", {}) if isinstance(status_data, dict) else {}
+            for agent_name, agent_row in agents.items():
+                agents_seen += 1
+                status = (agent_row.get("status", {}) if isinstance(agent_row, dict) else {}).get("state", "idle")
+                agent_presence_service.upsert(
+                    PresenceUpsertRequest(
+                        agent_name=f"{proj_name}:{agent_name}",
+                        agent_type=agent_name,
+                        team_name=proj_name,
+                        state=_map_presence_state(str(status)),
+                    )
+                )
+                presence_upserts += 1
+
+            # Emit one system summary line per project for quick operator visibility.
+            summary = status_data.get("summary", {}) if isinstance(status_data, dict) else {}
+            if summary:
+                msg = (
+                    f"[sync] {proj_name} "
+                    f"active={summary.get('active', 0)} "
+                    f"working={summary.get('working', 0)} "
+                    f"waiting={summary.get('waiting_input', 0)} "
+                    f"idle={summary.get('idle', 0)} "
+                    f"sleeping={summary.get('sleeping', 0)}"
+                )
+                agent_chat_service.create_message(
+                    room_key=proj_name,
+                    sender_type="system",
+                    sender_name="sync-bot",
+                    session_id=None,
+                    team_name=proj_name,
+                    message=msg,
+                    metadata_json={"event": "agent_office.sync"},
+                )
+                chat_messages += 1
+
+        return SyncResult(
+            source_url=url,
+            projects=len(projects),
+            agents_seen=agents_seen,
+            presence_upserts=presence_upserts,
+            chat_messages=chat_messages,
+        )
+
+
+agent_office_sync_service = AgentOfficeSyncService()
+

--- a/api/services/agent_presence_service.py
+++ b/api/services/agent_presence_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from api.database import SessionLocal
+from api.models.agent_presence import AgentPresence
+from api.schemas.agent_presence import PresenceUpsertRequest
+
+
+class AgentPresenceService:
+    def __init__(self, session_factory: Callable[[], Session] = SessionLocal) -> None:
+        self._session_factory = session_factory
+
+    def upsert(self, payload: PresenceUpsertRequest) -> AgentPresence:
+        with self._session_factory() as db:
+            row = db.scalar(select(AgentPresence).where(AgentPresence.agent_name == payload.agent_name))
+            if row is None:
+                row = AgentPresence(
+                    agent_name=payload.agent_name,
+                    agent_type=payload.agent_type,
+                    session_id=payload.session_id,
+                    team_name=payload.team_name,
+                    state=payload.state,
+                )
+                db.add(row)
+            else:
+                row.agent_type = payload.agent_type
+                row.session_id = payload.session_id
+                row.team_name = payload.team_name
+                row.state = payload.state
+            db.commit()
+            db.refresh(row)
+            return row
+
+    def list(self) -> list[AgentPresence]:
+        with self._session_factory() as db:
+            return list(db.scalars(select(AgentPresence).order_by(AgentPresence.last_seen_at.desc())).all())
+
+
+agent_presence_service = AgentPresenceService()
+

--- a/api/services/agent_task_service.py
+++ b/api/services/agent_task_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from api.database import SessionLocal
+from api.models.agent_task import AgentTask
+from api.schemas.agent_task import AgentTaskCreateRequest, AgentTaskUpdateRequest
+
+
+class AgentTaskService:
+    def __init__(self, session_factory: Callable[[], Session] = SessionLocal) -> None:
+        self._session_factory = session_factory
+
+    def _merge_metadata(self, base: dict[str, Any], incoming: dict[str, Any] | None) -> dict[str, Any]:
+        if not incoming:
+            return base
+        merged = dict(base or {})
+        merged.update(incoming)
+        return merged
+
+    def _apply_status_transition(self, task: AgentTask, next_status: str) -> None:
+        now = datetime.now(timezone.utc)
+        task.status = next_status
+        if next_status == "in_progress" and task.started_at is None:
+            task.started_at = now
+        if next_status == "completed":
+            if task.started_at is None:
+                task.started_at = now
+            task.completed_at = now
+
+    def create_task(self, payload: AgentTaskCreateRequest) -> AgentTask:
+        with self._session_factory() as db:
+            existing = db.scalar(select(AgentTask).where(AgentTask.task_id == payload.task_id))
+            if existing:
+                return existing
+
+            task = AgentTask(
+                task_id=payload.task_id,
+                session_id=payload.session_id,
+                agent_type=payload.agent_type,
+                team_name=payload.team_name,
+                subject=payload.subject,
+                description=payload.description,
+                status=payload.status,
+                files_modified=[],
+                metadata_json=payload.metadata_json or {},
+            )
+            task.mark_timestamps_from_status(payload.status)
+            db.add(task)
+            db.commit()
+            db.refresh(task)
+            return task
+
+    def update_task(self, task_id: str, payload: AgentTaskUpdateRequest) -> AgentTask | None:
+        with self._session_factory() as db:
+            task = db.scalar(select(AgentTask).where(AgentTask.task_id == task_id))
+            if task is None:
+                return None
+
+            if payload.session_id is not None:
+                task.session_id = payload.session_id
+            if payload.subject is not None:
+                task.subject = payload.subject
+            if payload.description is not None:
+                task.description = payload.description
+            if payload.files_modified is not None:
+                task.files_modified = payload.files_modified
+            if payload.metadata_json is not None:
+                task.metadata_json = self._merge_metadata(task.metadata_json or {}, payload.metadata_json)
+            if payload.status is not None and payload.status != task.status:
+                self._apply_status_transition(task, payload.status)
+
+            db.commit()
+            db.refresh(task)
+            return task
+
+    def get_task(self, task_id: str) -> AgentTask | None:
+        with self._session_factory() as db:
+            return db.scalar(select(AgentTask).where(AgentTask.task_id == task_id))
+
+    def list_tasks(
+        self,
+        *,
+        status: str | None = None,
+        agent_type: str | None = None,
+        session_id: str | None = None,
+        team_name: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[AgentTask], int]:
+        with self._session_factory() as db:
+            filters = []
+            if status:
+                filters.append(AgentTask.status == status)
+            if agent_type:
+                filters.append(AgentTask.agent_type == agent_type)
+            if session_id:
+                filters.append(AgentTask.session_id == session_id)
+            if team_name:
+                filters.append(AgentTask.team_name == team_name)
+
+            query: Select[tuple[AgentTask]] = select(AgentTask)
+            count_query = select(func.count(AgentTask.id))
+            if filters:
+                query = query.where(*filters)
+                count_query = count_query.where(*filters)
+
+            query = query.order_by(AgentTask.created_at.desc()).limit(limit).offset(offset)
+            total = db.scalar(count_query) or 0
+            tasks = list(db.scalars(query).all())
+            return tasks, int(total)
+
+    def delete_task(self, task_id: str) -> bool:
+        with self._session_factory() as db:
+            task = db.scalar(select(AgentTask).where(AgentTask.task_id == task_id))
+            if task is None:
+                return False
+            db.delete(task)
+            db.commit()
+            return True
+
+
+agent_task_service = AgentTaskService()
+

--- a/api/static/office.html
+++ b/api/static/office.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Agent Office</title>
+  <style>
+    :root { --bg:#0c111b; --panel:#131c2b; --line:#21324f; --text:#d9e7ff; --muted:#8da4c7; --ok:#22c55e; --warn:#f59e0b; --wait:#38bdf8; --done:#a78bfa; }
+    * { box-sizing: border-box; }
+    body { margin:0; background: radial-gradient(1300px 700px at 20% -10%, #1a2842 0%, var(--bg) 60%); color:var(--text); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .wrap { display:grid; grid-template-columns: 280px 1fr 360px; gap:12px; height:100vh; padding:12px; }
+    .panel { background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
+    .hd { padding:10px 12px; border-bottom:1px solid var(--line); font-size:13px; color:#a9c2e8; display:flex; justify-content:space-between; align-items:center; }
+    .bd { padding:10px; height:calc(100% - 42px); overflow:auto; }
+    .presence { display:flex; align-items:center; gap:8px; padding:6px 0; font-size:12px; }
+    .dot { width:8px; height:8px; border-radius:999px; }
+    .chat { display:flex; flex-direction:column; height:100%; }
+    .msgs { flex:1; overflow:auto; }
+    .msg { margin:8px 0; font-size:12px; line-height:1.35; }
+    .msg .who { color:#98b7e8; }
+    .msg .at { color:var(--muted); font-size:11px; margin-left:8px; }
+    .input { display:flex; gap:8px; margin-top:8px; }
+    input, select, button { border:1px solid var(--line); background:#0f1726; color:var(--text); padding:8px; border-radius:8px; font-size:12px; }
+    button { cursor:pointer; }
+    .graph { position:relative; min-height:600px; }
+    .node { position:absolute; width:210px; padding:8px; border:1px solid var(--line); border-radius:10px; background:#102038; font-size:12px; }
+    .node .id { color:#9dc0ef; font-size:11px; }
+    .badge { display:inline-block; margin-top:4px; padding:2px 6px; border-radius:999px; font-size:10px; }
+    .pending { background:#2a2f3a; }
+    .in_progress { background:#4a3a17; }
+    .completed { background:#2c2344; }
+    .deleted { background:#3a1f1f; }
+    svg { position:absolute; inset:0; pointer-events:none; }
+    .toolbar { display:flex; gap:8px; margin-bottom:8px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <section class="panel">
+      <div class="hd">Presence <span id="ws">ws: connecting</span></div>
+      <div class="bd" id="presence"></div>
+    </section>
+
+    <section class="panel">
+      <div class="hd">Task Graph</div>
+      <div class="bd">
+        <div class="toolbar">
+          <button id="refreshGraph">Refresh</button>
+          <input id="teamFilter" placeholder="team_name filter" />
+        </div>
+        <div id="graph" class="graph"><svg id="edges"></svg></div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="hd">Chat</div>
+      <div class="bd chat">
+        <div style="display:flex; gap:8px;">
+          <select id="room"><option value="general">general</option></select>
+          <input id="sender" value="operator" />
+        </div>
+        <div class="msgs" id="msgs"></div>
+        <div class="input">
+          <input id="text" placeholder="Type message..." style="flex:1;" />
+          <button id="send">Send</button>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const byId = (id) => document.getElementById(id);
+    const wsLabel = byId("ws");
+    const presenceEl = byId("presence");
+    const graphEl = byId("graph");
+    const edgesEl = byId("edges");
+    const msgsEl = byId("msgs");
+    const roomEl = byId("room");
+    const teamFilterEl = byId("teamFilter");
+
+    function fmtTs(ts) { return ts ? new Date(ts).toLocaleTimeString() : ""; }
+
+    async function fetchJson(url, opts) {
+      const res = await fetch(url, opts);
+      if (!res.ok) throw new Error(await res.text());
+      return await res.json();
+    }
+
+    async function loadPresence() {
+      const rows = await fetchJson("/api/agent-presence");
+      presenceEl.innerHTML = rows.map(r => {
+        const color = r.state === "active" ? "#22c55e" : (r.state === "idle" ? "#f59e0b" : "#6b7280");
+        return `<div class="presence"><span class="dot" style="background:${color}"></span><b>${r.agent_name}</b> <span style="color:#8da4c7">${r.state}</span></div>`;
+      }).join("");
+    }
+
+    function layout(nodes, edges) {
+      const parents = {};
+      const indeg = {};
+      nodes.forEach(n => { parents[n.id] = []; indeg[n.id] = 0; });
+      edges.forEach(e => { if (parents[e.target]) { parents[e.target].push(e.source); indeg[e.target] += 1; } });
+      const level = {};
+      const q = nodes.filter(n => indeg[n.id] === 0).map(n => n.id);
+      q.forEach(id => level[id] = 0);
+      while (q.length) {
+        const cur = q.shift();
+        edges.filter(e => e.source === cur).forEach(e => {
+          level[e.target] = Math.max(level[e.target] || 0, (level[cur] || 0) + 1);
+          indeg[e.target] -= 1;
+          if (indeg[e.target] === 0) q.push(e.target);
+        });
+      }
+      const lanes = {};
+      nodes.forEach(n => {
+        const l = level[n.id] || 0;
+        if (!lanes[l]) lanes[l] = [];
+        lanes[l].push(n);
+      });
+      const pos = {};
+      Object.entries(lanes).forEach(([l, list]) => {
+        list.forEach((n, i) => {
+          pos[n.id] = { x: 30 + Number(l) * 270, y: 30 + i * 120 };
+        });
+      });
+      return pos;
+    }
+
+    async function loadGraph() {
+      const team = teamFilterEl.value.trim();
+      const query = team ? `?team_name=${encodeURIComponent(team)}` : "";
+      const g = await fetchJson(`/api/agent-graph${query}`);
+      const pos = layout(g.nodes, g.edges);
+      graphEl.querySelectorAll(".node").forEach(n => n.remove());
+      g.nodes.forEach(n => {
+        const p = pos[n.id] || {x: 20, y: 20};
+        const el = document.createElement("div");
+        el.className = "node";
+        el.style.left = `${p.x}px`;
+        el.style.top = `${p.y}px`;
+        el.innerHTML = `<div><b>${n.label}</b></div><div class="id">${n.id}</div><span class="badge ${n.status}">${n.status}</span>`;
+        graphEl.appendChild(el);
+      });
+      edgesEl.setAttribute("width", String(graphEl.clientWidth));
+      edgesEl.setAttribute("height", String(Math.max(800, graphEl.scrollHeight)));
+      edgesEl.innerHTML = g.edges.map(e => {
+        const s = pos[e.source], t = pos[e.target];
+        if (!s || !t) return "";
+        const x1 = s.x + 210, y1 = s.y + 35, x2 = t.x, y2 = t.y + 35;
+        return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#3d5a86" stroke-width="2"/>`;
+      }).join("");
+    }
+
+    async function loadRoomsAndMessages() {
+      const rooms = await fetchJson("/api/agent-chat/rooms").catch(() => []);
+      if (rooms.length === 0) {
+        await fetchJson("/api/agent-chat/rooms", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify({room_key: "general", room_name: "General"})
+        });
+      }
+      const rows = await fetchJson("/api/agent-chat/rooms");
+      roomEl.innerHTML = rows.map(r => `<option value="${r.room_key}">${r.room_name}</option>`).join("");
+      await loadMessages();
+    }
+
+    async function loadMessages() {
+      const key = roomEl.value;
+      const rows = await fetchJson(`/api/agent-chat/messages?room_key=${encodeURIComponent(key)}&limit=100`);
+      msgsEl.innerHTML = rows.map(m => `<div class="msg"><span class="who">${m.sender_name}</span><span class="at">${fmtTs(m.created_at)}</span><div>${m.message}</div></div>`).join("");
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    }
+
+    async function sendMessage() {
+      const text = byId("text").value.trim();
+      if (!text) return;
+      await fetchJson("/api/agent-chat/messages", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({
+          room_key: roomEl.value,
+          sender_type: "user",
+          sender_name: byId("sender").value || "operator",
+          message: text,
+          metadata_json: {}
+        }),
+      });
+      byId("text").value = "";
+      await loadMessages();
+    }
+
+    function startWs() {
+      const ws = new WebSocket(`${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws/office`);
+      ws.onopen = () => { wsLabel.textContent = "ws: connected"; };
+      ws.onclose = () => { wsLabel.textContent = "ws: disconnected"; setTimeout(startWs, 1500); };
+      ws.onmessage = async (ev) => {
+        const msg = JSON.parse(ev.data);
+        if (msg.event_type.startsWith("chat.")) await loadMessages();
+        if (msg.event_type.startsWith("task.") || msg.event_type.startsWith("presence.")) {
+          await Promise.all([loadGraph(), loadPresence()]);
+        }
+      };
+      setInterval(() => { try { ws.send("ping"); } catch {} }, 15000);
+    }
+
+    byId("send").addEventListener("click", sendMessage);
+    byId("refreshGraph").addEventListener("click", loadGraph);
+    roomEl.addEventListener("change", loadMessages);
+    teamFilterEl.addEventListener("change", loadGraph);
+    byId("text").addEventListener("keydown", (e) => { if (e.key === "Enter") sendMessage(); });
+
+    Promise.all([loadPresence(), loadGraph(), loadRoomsAndMessages()]);
+    startWs();
+  </script>
+</body>
+</html>
+

--- a/api/static/office.html
+++ b/api/static/office.html
@@ -46,6 +46,7 @@
       <div class="bd">
         <div class="toolbar">
           <button id="refreshGraph">Refresh</button>
+          <button id="syncOffice">Sync Real Data</button>
           <input id="teamFilter" placeholder="team_name filter" />
         </div>
         <div id="graph" class="graph"><svg id="edges"></svg></div>
@@ -189,6 +190,15 @@
       await loadMessages();
     }
 
+    async function syncRealData() {
+      await fetchJson("/api/integrations/agent-office/sync", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({})
+      });
+      await Promise.all([loadPresence(), loadGraph(), loadRoomsAndMessages()]);
+    }
+
     function startWs() {
       const ws = new WebSocket(`${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws/office`);
       ws.onopen = () => { wsLabel.textContent = "ws: connected"; };
@@ -205,6 +215,7 @@
 
     byId("send").addEventListener("click", sendMessage);
     byId("refreshGraph").addEventListener("click", loadGraph);
+    byId("syncOffice").addEventListener("click", syncRealData);
     roomEl.addEventListener("change", loadMessages);
     teamFilterEl.addEventListener("change", loadGraph);
     byId("text").addEventListener("keydown", (e) => { if (e.key === "Enter") sendMessage(); });
@@ -214,4 +225,3 @@
   </script>
 </body>
 </html>
-

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110.0
+uvicorn>=0.29.0
+sqlalchemy>=2.0.0
+pydantic>=2.6.0
+


### PR DESCRIPTION
## Summary
- Add realtime collaboration stack (chat, presence, task graph, websocket)
- Add `/ui` office dashboard page
- Extend task flow with parent-child graph edges and realtime broadcasts
- Add integration endpoint to sync real data from `agent_office` status API
- Add PR-only contribution policy docs and PR template

## Main Changes
- API additions:
  - `GET /api/agent-graph`
  - `GET/POST /api/agent-chat/rooms`
  - `GET/POST /api/agent-chat/messages`
  - `GET/POST /api/agent-presence`
  - `POST /api/integrations/agent-office/sync`
  - `WS /ws/office`
  - `GET /ui`
- Hook update:
  - `.claude/hooks/agent-task-tracker.py` now forwards `parent_task_id` and presence upserts
- Docs/process:
  - `CONTRIBUTING.md`, `.github/pull_request_template.md`, updates to `AGENTS.md`, `WORKFLOW.md`, `README.md`

## Validation
- `python -m py_compile ...` passed for updated Python modules
- Runtime smoke checks passed for:
  - task create/update/list
  - chat room/message create/list
  - graph fetch
  - presence upsert/list
  - `/ui` page load
  - integration sync from `agent_office` endpoint

## Notes
- Default 운영 포트는 `8765` 유지
- 로컬에서 `8765` 점유 중일 때는 임시 포트(`8876`)로 검증함 (기능 검증 목적)
