### PR TITLE
feat: improve task workspace/chat UX and autosync controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ Execution workflow is documented in:
 - Follow PR-only policy:
   - Never merge by direct push to `main`.
   - Use feature branch -> PR -> review -> squash merge.
+- At task end, always include a short retrospective:
+  - user directives/corrections,
+  - delay causes,
+  - auto-approval candidates,
+  - next-run defaults.
 
 ## Codex Preflight Checklist
 - Git user is configured (`user.name`, `user.email`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,11 @@ Examples:
 - Add validation steps and results
 - Include screenshots for UI changes
 - Mention rollback plan for risky changes
+- Add a short retrospective in PR description/comment:
+  - user directives/corrections,
+  - delays encountered,
+  - automation opportunities (approved prefixes),
+  - defaults for next run.
 
 ## Local Flow
 ```bash
@@ -44,4 +49,3 @@ gh pr create --base main --fill
 3. Conversation resolved
 4. Squash merge
 5. Delete feature branch
-

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -44,6 +44,26 @@ git push -u origin feat/<topic>
 gh pr create --base main --fill
 ```
 
+## Post-Task Retrospective Rule (Mandatory)
+At the end of every task, include a short retrospective block in the final update:
+- `User Signals`: direct commands/corrections from user (what was emphasized)
+- `Waiting Causes`: approvals/network/env delays that slowed execution
+- `Automation Candidates`: command prefixes to auto-approve next time
+- `Next-Run Defaults`: concrete defaults to avoid re-asking
+
+Retrospective template:
+```text
+[Retrospective]
+User Signals:
+- ...
+Waiting Causes:
+- ...
+Automation Candidates:
+- ["..."]
+Next-Run Defaults:
+- ...
+```
+
 ## Validation Rule
 Run at minimum:
 ```bash

--- a/api/routers/agent_chat.py
+++ b/api/routers/agent_chat.py
@@ -43,7 +43,10 @@ async def create_message(payload: ChatMessageCreateRequest) -> ChatMessageRespon
 
 
 @router.get("/messages", response_model=list[ChatMessageResponse])
-def list_messages(room_key: str = Query(...), limit: int = Query(default=50, ge=1, le=200)) -> list[ChatMessageResponse]:
-    rows = agent_chat_service.list_messages(room_key=room_key, limit=limit)
+def list_messages(
+    room_key: str = Query(...),
+    limit: int = Query(default=50, ge=1, le=200),
+    before_id: int | None = Query(default=None, ge=1),
+) -> list[ChatMessageResponse]:
+    rows = agent_chat_service.list_messages(room_key=room_key, limit=limit, before_id=before_id)
     return [ChatMessageResponse.model_validate(r) for r in rows]
-

--- a/api/routers/agent_presence.py
+++ b/api/routers/agent_presence.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter
 
 from api.realtime import realtime_hub
@@ -12,7 +14,22 @@ router = APIRouter(prefix="/api/agent-presence", tags=["agent-presence"])
 @router.get("", response_model=list[PresenceResponse])
 def list_presence() -> list[PresenceResponse]:
     rows = agent_presence_service.list()
-    return [PresenceResponse.model_validate(r) for r in rows]
+    now = datetime.now(timezone.utc)
+    out: list[PresenceResponse] = []
+    for r in rows:
+        row = PresenceResponse.model_validate(r)
+        try:
+            last = row.last_seen_at.astimezone(timezone.utc)
+        except Exception:
+            last = now - timedelta(hours=24)
+        age = now - last
+        # Soft-state view: do not overwrite DB, just present stale agents as offline.
+        if age > timedelta(minutes=5):
+            row.state = "offline"
+        elif age > timedelta(minutes=2) and row.state == "active":
+            row.state = "idle"
+        out.append(row)
+    return out
 
 
 @router.post("", response_model=PresenceResponse)
@@ -21,4 +38,3 @@ async def upsert_presence(payload: PresenceUpsertRequest) -> PresenceResponse:
     response = PresenceResponse.model_validate(row)
     await realtime_hub.broadcast("presence.updated", response.model_dump(mode="json"))
     return response
-

--- a/api/services/agent_chat_service.py
+++ b/api/services/agent_chat_service.py
@@ -73,17 +73,15 @@ class AgentChatService:
             db.refresh(row)
             return row
 
-    def list_messages(self, room_key: str, limit: int = 50) -> list[AgentChatMessage]:
+    def list_messages(self, room_key: str, limit: int = 50, before_id: int | None = None) -> list[AgentChatMessage]:
         with self._session_factory() as db:
             room = db.scalar(select(AgentChatRoom).where(AgentChatRoom.room_key == room_key))
             if room is None:
                 return []
-            query = (
-                select(AgentChatMessage)
-                .where(AgentChatMessage.room_id == room.id)
-                .order_by(AgentChatMessage.created_at.desc())
-                .limit(limit)
-            )
+            query = select(AgentChatMessage).where(AgentChatMessage.room_id == room.id)
+            if before_id is not None:
+                query = query.where(AgentChatMessage.id < before_id)
+            query = query.order_by(AgentChatMessage.id.desc()).limit(limit)
             rows = list(db.scalars(query).all())
             rows.reverse()
             return rows

--- a/api/static/office.html
+++ b/api/static/office.html
@@ -5,33 +5,61 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Agent Office</title>
   <style>
-    :root { --bg:#0c111b; --panel:#131c2b; --line:#21324f; --text:#d9e7ff; --muted:#8da4c7; --ok:#22c55e; --warn:#f59e0b; --wait:#38bdf8; --done:#a78bfa; }
+    :root { --bg:#0c111b; --panel:#131c2b; --line:#21324f; --text:#d9e7ff; --muted:#8da4c7; }
     * { box-sizing: border-box; }
     body { margin:0; background: radial-gradient(1300px 700px at 20% -10%, #1a2842 0%, var(--bg) 60%); color:var(--text); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-    .wrap { display:grid; grid-template-columns: 280px 1fr 360px; gap:12px; height:100vh; padding:12px; }
+    .wrap { display:grid; grid-template-columns: 260px 1fr 380px; gap:12px; height:100vh; padding:12px; }
     .panel { background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; }
     .hd { padding:10px 12px; border-bottom:1px solid var(--line); font-size:13px; color:#a9c2e8; display:flex; justify-content:space-between; align-items:center; }
     .bd { padding:10px; height:calc(100% - 42px); overflow:auto; }
+
     .presence { display:flex; align-items:center; gap:8px; padding:6px 0; font-size:12px; }
     .dot { width:8px; height:8px; border-radius:999px; }
-    .chat { display:flex; flex-direction:column; height:100%; }
-    .msgs { flex:1; overflow:auto; }
-    .msg { margin:8px 0; font-size:12px; line-height:1.35; }
-    .msg .who { color:#98b7e8; }
-    .msg .at { color:var(--muted); font-size:11px; margin-left:8px; }
-    .input { display:flex; gap:8px; margin-top:8px; }
+
     input, select, button { border:1px solid var(--line); background:#0f1726; color:var(--text); padding:8px; border-radius:8px; font-size:12px; }
     button { cursor:pointer; }
-    .graph { position:relative; min-height:600px; }
-    .node { position:absolute; width:210px; padding:8px; border:1px solid var(--line); border-radius:10px; background:#102038; font-size:12px; }
-    .node .id { color:#9dc0ef; font-size:11px; }
-    .badge { display:inline-block; margin-top:4px; padding:2px 6px; border-radius:999px; font-size:10px; }
+    .btn-active { border-color:#4ea2ff; box-shadow: inset 0 0 0 1px #4ea2ff; }
+
+    .toolbar { display:grid; grid-template-columns:auto auto 120px 120px 140px 1fr auto auto; gap:8px; margin-bottom:8px; }
+    .syncbar { display:flex; align-items:center; gap:8px; margin-bottom:8px; font-size:11px; color:#9dbbe7; }
+    .pill { border:1px solid var(--line); border-radius:999px; padding:2px 8px; background:#102038; }
+    .err { border-color:#7f1d1d; background:#2a1218; color:#fecaca; }
+    .view.hidden { display:none; }
+
+    .task-board { border:1px solid var(--line); border-radius:10px; overflow:hidden; }
+    .task-head, .task-row { display:grid; grid-template-columns: 110px 1fr 110px 110px 100px; gap:8px; align-items:center; padding:8px 10px; font-size:12px; }
+    .task-head { background:#102038; color:#9dbbe7; border-bottom:1px solid var(--line); }
+    .task-row { border-bottom:1px solid #1b2942; cursor:pointer; }
+    .task-row:last-child { border-bottom:none; }
+    .task-row:hover { background:#0f1a2b; }
+    .task-row.active { background:#11233b; }
+    .badge { display:inline-block; padding:2px 6px; border-radius:999px; font-size:10px; }
     .pending { background:#2a2f3a; }
     .in_progress { background:#4a3a17; }
     .completed { background:#2c2344; }
     .deleted { background:#3a1f1f; }
+
+    .graph { position:relative; min-height:640px; border:1px solid var(--line); border-radius:10px; }
+    .node { position:absolute; width:220px; padding:8px; border:1px solid var(--line); border-radius:10px; background:#102038; font-size:12px; cursor:pointer; }
+    .node.active { border-color:#4ea2ff; box-shadow: inset 0 0 0 1px #4ea2ff; }
+    .node .id { color:#9dc0ef; font-size:11px; }
     svg { position:absolute; inset:0; pointer-events:none; }
-    .toolbar { display:flex; gap:8px; margin-bottom:8px; }
+    .legend { display:flex; gap:8px; margin-bottom:8px; font-size:11px; color:#9dbbe7; }
+    .chip { border:1px solid var(--line); border-radius:999px; padding:2px 8px; background:#102038; }
+
+    .chat { display:grid; grid-template-rows:auto auto 1fr auto 200px; gap:8px; height:100%; }
+    .msgs { overflow:auto; border:1px solid var(--line); border-radius:8px; padding:8px; }
+    .msg { margin:8px 0; font-size:12px; line-height:1.35; }
+    .msg .who { color:#98b7e8; }
+    .msg .at { color:var(--muted); font-size:11px; margin-left:8px; }
+    .msg.user .who { color:#7dd3fc; }
+    .msg.agent .who { color:#86efac; }
+    .msg.system { border-left:2px solid #4ea2ff; padding-left:8px; }
+    .msg.system .who { color:#c4b5fd; }
+    .input { display:flex; gap:8px; }
+    .detail { border:1px solid var(--line); border-radius:8px; padding:8px; font-size:12px; overflow:auto; background:#0f1726; }
+    .detail .k { color:#8da4c7; width:90px; display:inline-block; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
   </style>
 </head>
 <body>
@@ -42,29 +70,80 @@
     </section>
 
     <section class="panel">
-      <div class="hd">Task Graph</div>
+      <div class="hd">Task Workspace</div>
       <div class="bd">
         <div class="toolbar">
-          <button id="refreshGraph">Refresh</button>
+          <button id="modeBoard" class="btn-active">Board</button>
+          <button id="modeGraph">Graph</button>
+          <select id="statusFilter">
+            <option value="">all status</option>
+            <option value="pending">pending</option>
+            <option value="in_progress">in_progress</option>
+            <option value="completed">completed</option>
+            <option value="deleted">deleted</option>
+          </select>
+          <input id="agentFilter" placeholder="agent type" />
+          <input id="teamFilter" placeholder="team name" />
+          <input id="qFilter" placeholder="search subject/task_id" />
+          <button id="refreshAll">Refresh</button>
           <button id="syncOffice">Sync Real Data</button>
-          <input id="teamFilter" placeholder="team_name filter" />
         </div>
-        <div id="graph" class="graph"><svg id="edges"></svg></div>
+        <div class="syncbar">
+          <input id="syncSourceUrl" style="min-width:420px;" value="http://127.0.0.1:8766/api/agent-office/status" />
+        </div>
+        <div class="syncbar">
+          <label class="pill"><input id="autoSync" type="checkbox" style="vertical-align:middle;" /> auto-sync</label>
+          <select id="autoSyncSec">
+            <option value="10">10s</option>
+            <option value="20" selected>20s</option>
+            <option value="30">30s</option>
+            <option value="60">60s</option>
+          </select>
+          <span class="pill" id="lastSync">last sync: -</span>
+          <span class="pill" id="syncStatus">sync: idle</span>
+          <span class="pill" id="wsRtt">ws rtt: -</span>
+        </div>
+        <div id="errorBanner" class="pill err hidden"></div>
+
+        <div id="boardView" class="view">
+          <div class="task-board">
+            <div class="task-head">
+              <div>task_id</div><div>subject</div><div>status</div><div>team</div><div>updated</div>
+            </div>
+            <div id="taskRows"></div>
+          </div>
+        </div>
+
+        <div id="graphView" class="view hidden">
+          <div class="legend">
+            <span class="chip">edge: spawned</span>
+            <span class="chip">edge: related</span>
+            <span class="chip">click node to pin detail</span>
+          </div>
+          <div id="graph" class="graph"><svg id="edges"></svg></div>
+        </div>
       </div>
     </section>
 
     <section class="panel">
-      <div class="hd">Chat</div>
+      <div class="hd">Chat + Task Detail</div>
       <div class="bd chat">
         <div style="display:flex; gap:8px;">
           <select id="room"><option value="general">general</option></select>
           <input id="sender" value="operator" />
+        </div>
+        <div style="display:flex; gap:8px;">
+          <input id="newRoomKey" placeholder="new room key" />
+          <input id="newRoomName" placeholder="new room name" />
+          <button id="createRoom">Create Room</button>
+          <button id="loadOlder">Load Older</button>
         </div>
         <div class="msgs" id="msgs"></div>
         <div class="input">
           <input id="text" placeholder="Type message..." style="flex:1;" />
           <button id="send">Send</button>
         </div>
+        <div class="detail" id="taskDetail">Select a task from board/graph to see details.</div>
       </div>
     </section>
   </div>
@@ -75,11 +154,48 @@
     const presenceEl = byId("presence");
     const graphEl = byId("graph");
     const edgesEl = byId("edges");
+    const taskRowsEl = byId("taskRows");
+    const taskDetailEl = byId("taskDetail");
     const msgsEl = byId("msgs");
     const roomEl = byId("room");
-    const teamFilterEl = byId("teamFilter");
+    const lastSyncEl = byId("lastSync");
+    const syncStatusEl = byId("syncStatus");
+    const autoSyncEl = byId("autoSync");
+    const autoSyncSecEl = byId("autoSyncSec");
+    const errEl = byId("errorBanner");
+    const wsRttEl = byId("wsRtt");
+    const syncSourceUrlEl = byId("syncSourceUrl");
 
-    function fmtTs(ts) { return ts ? new Date(ts).toLocaleTimeString() : ""; }
+    const modeBoardBtn = byId("modeBoard");
+    const modeGraphBtn = byId("modeGraph");
+    const boardView = byId("boardView");
+    const graphView = byId("graphView");
+
+    const statusFilterEl = byId("statusFilter");
+    const agentFilterEl = byId("agentFilter");
+    const teamFilterEl = byId("teamFilter");
+    const qFilterEl = byId("qFilter");
+
+    let taskList = [];
+    let graphData = { nodes: [], edges: [] };
+    let selectedTaskId = null;
+    let oldestMessageId = null;
+    let autoSyncTimer = null;
+    let wsReconnectDelayMs = 1000;
+    let wsHeartbeatTimer = null;
+    let wsPingAt = 0;
+
+    function fmtTs(ts) { return ts ? new Date(ts).toLocaleString() : "-"; }
+    function esc(s) { return String(s ?? "").replace(/[&<>\"]/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c])); }
+    function showError(msg) {
+      if (!msg) {
+        errEl.textContent = "";
+        errEl.classList.add("hidden");
+        return;
+      }
+      errEl.textContent = msg;
+      errEl.classList.remove("hidden");
+    }
 
     async function fetchJson(url, opts) {
       const res = await fetch(url, opts);
@@ -87,22 +203,84 @@
       return await res.json();
     }
 
+    function setMode(mode) {
+      const board = mode === "board";
+      boardView.classList.toggle("hidden", !board);
+      graphView.classList.toggle("hidden", board);
+      modeBoardBtn.classList.toggle("btn-active", board);
+      modeGraphBtn.classList.toggle("btn-active", !board);
+    }
+
     async function loadPresence() {
       const rows = await fetchJson("/api/agent-presence");
       presenceEl.innerHTML = rows.map(r => {
         const color = r.state === "active" ? "#22c55e" : (r.state === "idle" ? "#f59e0b" : "#6b7280");
-        return `<div class="presence"><span class="dot" style="background:${color}"></span><b>${r.agent_name}</b> <span style="color:#8da4c7">${r.state}</span></div>`;
+        return `<div class="presence"><span class="dot" style="background:${color}"></span><b>${esc(r.agent_name)}</b> <span style="color:#8da4c7">${esc(r.state)}</span></div>`;
       }).join("");
     }
 
+    function renderTaskDetail() {
+      const t = taskList.find(x => x.task_id === selectedTaskId) || null;
+      if (!t) {
+        taskDetailEl.innerHTML = "Select a task from board/graph to see details.";
+        return;
+      }
+      const files = Array.isArray(t.files_modified) ? t.files_modified : [];
+      const meta = t.metadata_json ? JSON.stringify(t.metadata_json, null, 2) : "{}";
+      taskDetailEl.innerHTML = [
+        `<div><span class="k">task_id</span><b class="mono">${esc(t.task_id)}</b></div>`,
+        `<div><span class="k">subject</span>${esc(t.subject)}</div>`,
+        `<div><span class="k">status</span><span class="badge ${esc(t.status)}">${esc(t.status)}</span></div>`,
+        `<div><span class="k">agent</span>${esc(t.agent_type || "-")}</div>`,
+        `<div><span class="k">team</span>${esc(t.team_name || "-")}</div>`,
+        `<div><span class="k">session</span>${esc(t.session_id || "-")}</div>`,
+        `<div><span class="k">created</span>${fmtTs(t.created_at)}</div>`,
+        `<div><span class="k">updated</span>${fmtTs(t.updated_at)}</div>`,
+        `<div style="margin-top:6px;"><span class="k">files</span>${files.length ? files.map(esc).join(", ") : "-"}</div>`,
+        `<div style="margin-top:6px;"><span class="k">metadata</span></div>`,
+        `<pre class="mono" style="white-space:pre-wrap; margin:4px 0 0;">${esc(meta)}</pre>`
+      ].join("");
+    }
+
+    function renderTaskRows() {
+      const q = qFilterEl.value.trim().toLowerCase();
+      const a = agentFilterEl.value.trim().toLowerCase();
+      const filtered = taskList.filter(t => {
+        const okQ = !q || String(t.task_id).toLowerCase().includes(q) || String(t.subject).toLowerCase().includes(q);
+        const okA = !a || String(t.agent_type || "").toLowerCase().includes(a);
+        return okQ && okA;
+      });
+      taskRowsEl.innerHTML = filtered.map(t => {
+        const active = t.task_id === selectedTaskId ? "active" : "";
+        return `<div class="task-row ${active}" data-id="${esc(t.task_id)}">
+          <div class="mono">${esc(t.task_id)}</div>
+          <div>${esc(t.subject)}</div>
+          <div><span class="badge ${esc(t.status)}">${esc(t.status)}</span></div>
+          <div>${esc(t.team_name || "-")}</div>
+          <div>${fmtTs(t.updated_at)}</div>
+        </div>`;
+      }).join("");
+
+      taskRowsEl.querySelectorAll(".task-row").forEach(el => {
+        el.addEventListener("click", () => {
+          selectedTaskId = el.dataset.id;
+          renderTaskRows();
+          renderTaskDetail();
+          renderGraph();
+        });
+      });
+
+      if (!selectedTaskId && filtered.length > 0) selectedTaskId = filtered[0].task_id;
+      renderTaskDetail();
+    }
+
     function layout(nodes, edges) {
-      const parents = {};
       const indeg = {};
-      nodes.forEach(n => { parents[n.id] = []; indeg[n.id] = 0; });
-      edges.forEach(e => { if (parents[e.target]) { parents[e.target].push(e.source); indeg[e.target] += 1; } });
+      nodes.forEach(n => { indeg[n.id] = 0; });
+      edges.forEach(e => { if (indeg[e.target] !== undefined) indeg[e.target] += 1; });
       const level = {};
       const q = nodes.filter(n => indeg[n.id] === 0).map(n => n.id);
-      q.forEach(id => level[id] = 0);
+      q.forEach(id => { level[id] = 0; });
       while (q.length) {
         const cur = q.shift();
         edges.filter(e => e.source === cur).forEach(e => {
@@ -119,36 +297,62 @@
       });
       const pos = {};
       Object.entries(lanes).forEach(([l, list]) => {
-        list.forEach((n, i) => {
-          pos[n.id] = { x: 30 + Number(l) * 270, y: 30 + i * 120 };
-        });
+        list.forEach((n, i) => { pos[n.id] = { x: 20 + Number(l) * 280, y: 20 + i * 120 }; });
       });
       return pos;
+    }
+
+    function renderGraph() {
+      const g = graphData;
+      const pos = layout(g.nodes, g.edges);
+      graphEl.querySelectorAll(".node").forEach(n => n.remove());
+      g.nodes.forEach(n => {
+        const p = pos[n.id] || {x: 20, y: 20};
+        const active = n.id === selectedTaskId ? "active" : "";
+        const el = document.createElement("div");
+        el.className = `node ${active}`;
+        el.style.left = `${p.x}px`;
+        el.style.top = `${p.y}px`;
+        el.innerHTML = `<div><b>${esc(n.label)}</b></div><div class="id">${esc(n.id)}</div><span class="badge ${esc(n.status)}">${esc(n.status)}</span>`;
+        el.addEventListener("click", () => {
+          selectedTaskId = n.id;
+          renderGraph();
+          renderTaskRows();
+          renderTaskDetail();
+        });
+        graphEl.appendChild(el);
+      });
+      edgesEl.setAttribute("width", String(graphEl.clientWidth));
+      edgesEl.setAttribute("height", String(Math.max(700, graphEl.scrollHeight)));
+      edgesEl.innerHTML = g.edges.map(e => {
+        const s = pos[e.source], t = pos[e.target];
+        if (!s || !t) return "";
+        const x1 = s.x + 220, y1 = s.y + 35, x2 = t.x, y2 = t.y + 35;
+        const mx = (x1 + x2) / 2;
+        const my = (y1 + y2) / 2 - 5;
+        return `<g>
+          <line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#3d5a86" stroke-width="2"/>
+          <text x="${mx}" y="${my}" fill="#9dbbe7" font-size="10" text-anchor="middle">${esc(e.edge_type || "edge")}</text>
+        </g>`;
+      }).join("");
+    }
+
+    async function loadTasks() {
+      const status = statusFilterEl.value.trim();
+      const team = teamFilterEl.value.trim();
+      const params = new URLSearchParams({ limit: "400", offset: "0" });
+      if (status) params.set("status", status);
+      if (team) params.set("team_name", team);
+      const data = await fetchJson(`/api/agent-tasks?${params.toString()}`);
+      taskList = Array.isArray(data.tasks) ? data.tasks : [];
+      renderTaskRows();
     }
 
     async function loadGraph() {
       const team = teamFilterEl.value.trim();
       const query = team ? `?team_name=${encodeURIComponent(team)}` : "";
-      const g = await fetchJson(`/api/agent-graph${query}`);
-      const pos = layout(g.nodes, g.edges);
-      graphEl.querySelectorAll(".node").forEach(n => n.remove());
-      g.nodes.forEach(n => {
-        const p = pos[n.id] || {x: 20, y: 20};
-        const el = document.createElement("div");
-        el.className = "node";
-        el.style.left = `${p.x}px`;
-        el.style.top = `${p.y}px`;
-        el.innerHTML = `<div><b>${n.label}</b></div><div class="id">${n.id}</div><span class="badge ${n.status}">${n.status}</span>`;
-        graphEl.appendChild(el);
-      });
-      edgesEl.setAttribute("width", String(graphEl.clientWidth));
-      edgesEl.setAttribute("height", String(Math.max(800, graphEl.scrollHeight)));
-      edgesEl.innerHTML = g.edges.map(e => {
-        const s = pos[e.source], t = pos[e.target];
-        if (!s || !t) return "";
-        const x1 = s.x + 210, y1 = s.y + 35, x2 = t.x, y2 = t.y + 35;
-        return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#3d5a86" stroke-width="2"/>`;
-      }).join("");
+      graphData = await fetchJson(`/api/agent-graph${query}`);
+      renderGraph();
     }
 
     async function loadRoomsAndMessages() {
@@ -161,15 +365,30 @@
         });
       }
       const rows = await fetchJson("/api/agent-chat/rooms");
-      roomEl.innerHTML = rows.map(r => `<option value="${r.room_key}">${r.room_name}</option>`).join("");
-      await loadMessages();
+      roomEl.innerHTML = rows.map(r => `<option value="${esc(r.room_key)}">${esc(r.room_name)}</option>`).join("");
+      oldestMessageId = null;
+      await loadMessages({ reset: true });
     }
 
-    async function loadMessages() {
+    function renderMessages(rows, prepend = false) {
+      const html = rows.map(m => `<div class="msg ${esc(m.sender_type || "agent")}" data-id="${m.id}"><span class="who">${esc(m.sender_name)}</span><span class="at">${fmtTs(m.created_at)}</span><div>${esc(m.message)}</div></div>`).join("");
+      if (prepend) {
+        msgsEl.innerHTML = html + msgsEl.innerHTML;
+      } else {
+        msgsEl.innerHTML = html;
+      }
+      if (!prepend) msgsEl.scrollTop = msgsEl.scrollHeight;
+    }
+
+    async function loadMessages({ reset = false, prepend = false } = {}) {
       const key = roomEl.value;
-      const rows = await fetchJson(`/api/agent-chat/messages?room_key=${encodeURIComponent(key)}&limit=100`);
-      msgsEl.innerHTML = rows.map(m => `<div class="msg"><span class="who">${m.sender_name}</span><span class="at">${fmtTs(m.created_at)}</span><div>${m.message}</div></div>`).join("");
-      msgsEl.scrollTop = msgsEl.scrollHeight;
+      const params = new URLSearchParams({ room_key: key, limit: "60" });
+      if (!reset && oldestMessageId) params.set("before_id", String(oldestMessageId));
+      const rows = await fetchJson(`/api/agent-chat/messages?${params.toString()}`);
+      if (rows.length > 0) {
+        oldestMessageId = rows[0].id;
+      }
+      renderMessages(rows, prepend);
     }
 
     async function sendMessage() {
@@ -184,44 +403,132 @@
           sender_name: byId("sender").value || "operator",
           message: text,
           metadata_json: {}
-        }),
+        })
       });
       byId("text").value = "";
-      await loadMessages();
+      oldestMessageId = null;
+      await loadMessages({ reset: true });
+    }
+
+    async function createRoom() {
+      const key = byId("newRoomKey").value.trim();
+      const name = byId("newRoomName").value.trim() || key;
+      if (!key) return;
+      await fetchJson("/api/agent-chat/rooms", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({ room_key: key, room_name: name })
+      });
+      byId("newRoomKey").value = "";
+      byId("newRoomName").value = "";
+      await loadRoomsAndMessages();
+      roomEl.value = key;
+      oldestMessageId = null;
+      await loadMessages({ reset: true });
+    }
+
+    async function loadOlderMessages() {
+      const prevHeight = msgsEl.scrollHeight;
+      await loadMessages({ prepend: true });
+      msgsEl.scrollTop = msgsEl.scrollHeight - prevHeight;
     }
 
     async function syncRealData() {
-      await fetchJson("/api/integrations/agent-office/sync", {
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({})
-      });
-      await Promise.all([loadPresence(), loadGraph(), loadRoomsAndMessages()]);
+      try {
+        syncStatusEl.textContent = "sync: running";
+        showError("");
+        await fetchJson("/api/integrations/agent-office/sync", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify({ source_url: syncSourceUrlEl.value.trim() || undefined })
+        });
+        lastSyncEl.textContent = `last sync: ${new Date().toLocaleTimeString()}`;
+        syncStatusEl.textContent = "sync: ok";
+        await refreshAll();
+      } catch (e) {
+        syncStatusEl.textContent = "sync: failed";
+        showError(`sync failed: ${String(e.message || e)}`);
+      }
+    }
+
+    function resetAutoSyncTimer() {
+      if (autoSyncTimer) {
+        clearInterval(autoSyncTimer);
+        autoSyncTimer = null;
+      }
+      if (!autoSyncEl.checked) return;
+      const ms = Number(autoSyncSecEl.value || "20") * 1000;
+      autoSyncTimer = setInterval(() => { syncRealData(); }, ms);
+    }
+
+    async function refreshAll() {
+      await Promise.all([loadPresence(), loadTasks(), loadGraph(), loadRoomsAndMessages()]);
     }
 
     function startWs() {
       const ws = new WebSocket(`${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws/office`);
-      ws.onopen = () => { wsLabel.textContent = "ws: connected"; };
-      ws.onclose = () => { wsLabel.textContent = "ws: disconnected"; setTimeout(startWs, 1500); };
+      ws.onopen = () => {
+        wsLabel.textContent = "ws: connected";
+        wsReconnectDelayMs = 1000;
+        if (wsHeartbeatTimer) clearInterval(wsHeartbeatTimer);
+        wsHeartbeatTimer = setInterval(() => {
+          try {
+            wsPingAt = Date.now();
+            ws.send("ping");
+          } catch {}
+        }, 15000);
+      };
+      ws.onclose = () => {
+        wsLabel.textContent = `ws: reconnecting in ${Math.round(wsReconnectDelayMs / 1000)}s`;
+        if (wsHeartbeatTimer) clearInterval(wsHeartbeatTimer);
+        setTimeout(startWs, wsReconnectDelayMs);
+        wsReconnectDelayMs = Math.min(10000, wsReconnectDelayMs * 2);
+      };
       ws.onmessage = async (ev) => {
         const msg = JSON.parse(ev.data);
-        if (msg.event_type.startsWith("chat.")) await loadMessages();
-        if (msg.event_type.startsWith("task.") || msg.event_type.startsWith("presence.")) {
-          await Promise.all([loadGraph(), loadPresence()]);
+        if (wsPingAt > 0) {
+          wsRttEl.textContent = `ws rtt: ${Date.now() - wsPingAt}ms`;
+          wsPingAt = 0;
+        }
+        if (msg.event_type.startsWith("chat.")) {
+          oldestMessageId = null;
+          await loadMessages({ reset: true });
+        }
+        if (msg.event_type.startsWith("task.") || msg.event_type.startsWith("presence.") || msg.event_type.startsWith("integration.")) {
+          await Promise.all([loadPresence(), loadTasks(), loadGraph()]);
         }
       };
-      setInterval(() => { try { ws.send("ping"); } catch {} }, 15000);
     }
 
+    modeBoardBtn.addEventListener("click", () => setMode("board"));
+    modeGraphBtn.addEventListener("click", () => setMode("graph"));
+
     byId("send").addEventListener("click", sendMessage);
-    byId("refreshGraph").addEventListener("click", loadGraph);
+    byId("createRoom").addEventListener("click", createRoom);
+    byId("loadOlder").addEventListener("click", loadOlderMessages);
+    byId("refreshAll").addEventListener("click", refreshAll);
     byId("syncOffice").addEventListener("click", syncRealData);
-    roomEl.addEventListener("change", loadMessages);
-    teamFilterEl.addEventListener("change", loadGraph);
+    autoSyncEl.addEventListener("change", resetAutoSyncTimer);
+    autoSyncSecEl.addEventListener("change", resetAutoSyncTimer);
+
+    roomEl.addEventListener("change", async () => {
+      oldestMessageId = null;
+      await loadMessages({ reset: true });
+    });
+    [statusFilterEl, agentFilterEl, teamFilterEl, qFilterEl].forEach(el => {
+      el.addEventListener("change", async () => { await Promise.all([loadTasks(), loadGraph()]); });
+      el.addEventListener("keyup", async (e) => {
+        if (e.key === "Enter" || el === qFilterEl || el === agentFilterEl) {
+          await Promise.all([loadTasks(), loadGraph()]);
+        }
+      });
+    });
     byId("text").addEventListener("keydown", (e) => { if (e.key === "Enter") sendMessage(); });
 
-    Promise.all([loadPresence(), loadGraph(), loadRoomsAndMessages()]);
+    setMode("board");
+    refreshAll();
     startWs();
+    resetAutoSyncTimer();
   </script>
 </body>
 </html>

--- a/api/static/office.html
+++ b/api/static/office.html
@@ -99,8 +99,16 @@
             <option value="30">30s</option>
             <option value="60">60s</option>
           </select>
+          <span class="pill">graph limit</span>
+          <select id="graphLimit">
+            <option value="80">80</option>
+            <option value="120" selected>120</option>
+            <option value="200">200</option>
+            <option value="400">400</option>
+          </select>
           <span class="pill" id="lastSync">last sync: -</span>
           <span class="pill" id="syncStatus">sync: idle</span>
+          <span class="pill" id="graphStats">graph: -</span>
           <span class="pill" id="wsRtt">ws rtt: -</span>
         </div>
         <div id="errorBanner" class="pill err hidden"></div>
@@ -165,6 +173,8 @@
     const errEl = byId("errorBanner");
     const wsRttEl = byId("wsRtt");
     const syncSourceUrlEl = byId("syncSourceUrl");
+    const graphLimitEl = byId("graphLimit");
+    const graphStatsEl = byId("graphStats");
 
     const modeBoardBtn = byId("modeBoard");
     const modeGraphBtn = byId("modeGraph");
@@ -351,8 +361,33 @@
       return pos;
     }
 
+    function getVisibleGraph() {
+      const maxNodes = Number(graphLimitEl.value || "120");
+      const nodes = graphData.nodes || [];
+      const edges = graphData.edges || [];
+      if (nodes.length <= maxNodes) {
+        return { nodes, edges };
+      }
+      const scoreById = {};
+      taskList.forEach((t, idx) => {
+        const freshness = taskList.length - idx;
+        const statusBoost = t.status === "in_progress" ? 1000 : (t.status === "pending" ? 400 : 0);
+        scoreById[t.task_id] = freshness + statusBoost;
+      });
+      const ranked = [...nodes].sort((a, b) => (scoreById[b.id] || 0) - (scoreById[a.id] || 0));
+      const picked = ranked.slice(0, maxNodes).map(n => n.id);
+      if (selectedTaskId && !picked.includes(selectedTaskId)) {
+        picked[picked.length - 1] = selectedTaskId;
+      }
+      const pickedSet = new Set(picked);
+      return {
+        nodes: nodes.filter(n => pickedSet.has(n.id)),
+        edges: edges.filter(e => pickedSet.has(e.source) && pickedSet.has(e.target)),
+      };
+    }
+
     function renderGraph() {
-      const g = graphData;
+      const g = getVisibleGraph();
       const pos = layout(g.nodes, g.edges);
       graphEl.querySelectorAll(".node").forEach(n => n.remove());
       g.nodes.forEach(n => {
@@ -387,6 +422,7 @@
           <text x="${mx}" y="${my}" fill="#9dbbe7" font-size="10" text-anchor="middle">${esc(e.edge_type || "edge")}</text>
         </g>`;
       }).join("");
+      graphStatsEl.textContent = `graph: ${g.nodes.length}n / ${g.edges.length}e`;
     }
 
     async function loadTasks() {
@@ -562,6 +598,7 @@
     byId("syncOffice").addEventListener("click", syncRealData);
     autoSyncEl.addEventListener("change", resetAutoSyncTimer);
     autoSyncSecEl.addEventListener("change", resetAutoSyncTimer);
+    graphLimitEl.addEventListener("change", renderGraph);
 
     roomEl.addEventListener("change", async () => {
       oldestMessageId = null;

--- a/api/static/office.html
+++ b/api/static/office.html
@@ -106,6 +106,7 @@
             <option value="200">200</option>
             <option value="400">400</option>
           </select>
+          <label class="pill"><input id="showNodeId" type="checkbox" style="vertical-align:middle;" /> show id</label>
           <span class="pill" id="lastSync">last sync: -</span>
           <span class="pill" id="syncStatus">sync: idle</span>
           <span class="pill" id="graphStats">graph: -</span>
@@ -175,6 +176,7 @@
     const syncSourceUrlEl = byId("syncSourceUrl");
     const graphLimitEl = byId("graphLimit");
     const graphStatsEl = byId("graphStats");
+    const showNodeIdEl = byId("showNodeId");
 
     const modeBoardBtn = byId("modeBoard");
     const modeGraphBtn = byId("modeGraph");
@@ -397,7 +399,8 @@
         el.className = `node ${active}`;
         el.style.left = `${p.x}px`;
         el.style.top = `${p.y}px`;
-        el.innerHTML = `<div><b>${esc(n.label)}</b></div><div class="id">${esc(n.id)}</div><span class="badge ${esc(n.status)}">${esc(n.status)}</span>`;
+        const idLine = showNodeIdEl.checked ? `<div class="id">id: ${esc(n.id)}</div>` : "";
+        el.innerHTML = `<div><b>${esc(n.label)}</b></div>${idLine}<span class="badge ${esc(n.status)}">${esc(n.status)}</span>`;
         el.addEventListener("click", () => {
           selectedTaskId = n.id;
           renderGraph();
@@ -599,6 +602,7 @@
     autoSyncEl.addEventListener("change", resetAutoSyncTimer);
     autoSyncSecEl.addEventListener("change", resetAutoSyncTimer);
     graphLimitEl.addEventListener("change", renderGraph);
+    showNodeIdEl.addEventListener("change", renderGraph);
 
     roomEl.addEventListener("change", async () => {
       oldestMessageId = null;

--- a/api/static/office.html
+++ b/api/static/office.html
@@ -275,30 +275,79 @@
     }
 
     function layout(nodes, edges) {
-      const indeg = {};
-      nodes.forEach(n => { indeg[n.id] = 0; });
-      edges.forEach(e => { if (indeg[e.target] !== undefined) indeg[e.target] += 1; });
-      const level = {};
-      const q = nodes.filter(n => indeg[n.id] === 0).map(n => n.id);
-      q.forEach(id => { level[id] = 0; });
-      while (q.length) {
-        const cur = q.shift();
-        edges.filter(e => e.source === cur).forEach(e => {
-          level[e.target] = Math.max(level[e.target] || 0, (level[cur] || 0) + 1);
-          indeg[e.target] -= 1;
-          if (indeg[e.target] === 0) q.push(e.target);
-        });
+      const byId = new Map(nodes.map(n => [n.id, n]));
+      const out = new Map(nodes.map(n => [n.id, []]));
+      const undirected = new Map(nodes.map(n => [n.id, new Set()]));
+      const indeg = Object.fromEntries(nodes.map(n => [n.id, 0]));
+
+      edges.forEach(e => {
+        if (!byId.has(e.source) || !byId.has(e.target)) return;
+        out.get(e.source).push(e.target);
+        undirected.get(e.source).add(e.target);
+        undirected.get(e.target).add(e.source);
+        indeg[e.target] += 1;
+      });
+
+      // connected components for better packing of disjoint subgraphs
+      const components = [];
+      const seen = new Set();
+      for (const n of nodes) {
+        if (seen.has(n.id)) continue;
+        const stack = [n.id];
+        const comp = [];
+        seen.add(n.id);
+        while (stack.length) {
+          const cur = stack.pop();
+          comp.push(cur);
+          for (const nxt of undirected.get(cur)) {
+            if (!seen.has(nxt)) {
+              seen.add(nxt);
+              stack.push(nxt);
+            }
+          }
+        }
+        components.push(comp);
       }
-      const lanes = {};
-      nodes.forEach(n => {
-        const l = level[n.id] || 0;
-        if (!lanes[l]) lanes[l] = [];
-        lanes[l].push(n);
-      });
+
       const pos = {};
-      Object.entries(lanes).forEach(([l, list]) => {
-        list.forEach((n, i) => { pos[n.id] = { x: 20 + Number(l) * 280, y: 20 + i * 120 }; });
-      });
+      const xGap = 300;
+      const yGap = 128;
+      let yOffset = 20;
+
+      for (const comp of components) {
+        const compSet = new Set(comp);
+        const compIndeg = {};
+        comp.forEach(id => { compIndeg[id] = indeg[id] || 0; });
+        const q = comp.filter(id => compIndeg[id] === 0);
+        const level = Object.fromEntries(comp.map(id => [id, 0]));
+        while (q.length) {
+          const cur = q.shift();
+          for (const nxt of out.get(cur) || []) {
+            if (!compSet.has(nxt)) continue;
+            level[nxt] = Math.max(level[nxt], level[cur] + 1);
+            compIndeg[nxt] -= 1;
+            if (compIndeg[nxt] === 0) q.push(nxt);
+          }
+        }
+
+        const lanes = {};
+        comp.forEach(id => {
+          const l = level[id] || 0;
+          if (!lanes[l]) lanes[l] = [];
+          lanes[l].push(byId.get(id));
+        });
+
+        const laneKeys = Object.keys(lanes).map(Number).sort((a, b) => a - b);
+        let compHeight = 0;
+        for (const lk of laneKeys) {
+          const list = lanes[lk].sort((a, b) => String(a.label).localeCompare(String(b.label)));
+          list.forEach((n, i) => {
+            pos[n.id] = { x: 20 + lk * xGap, y: yOffset + i * yGap };
+          });
+          compHeight = Math.max(compHeight, list.length * yGap);
+        }
+        yOffset += Math.max(160, compHeight + 40);
+      }
       return pos;
     }
 
@@ -322,8 +371,11 @@
         });
         graphEl.appendChild(el);
       });
-      edgesEl.setAttribute("width", String(graphEl.clientWidth));
-      edgesEl.setAttribute("height", String(Math.max(700, graphEl.scrollHeight)));
+      const maxX = Math.max(0, ...Object.values(pos).map(p => p.x));
+      const maxY = Math.max(0, ...Object.values(pos).map(p => p.y));
+      edgesEl.setAttribute("width", String(Math.max(graphEl.clientWidth, maxX + 320)));
+      edgesEl.setAttribute("height", String(Math.max(700, maxY + 220)));
+      graphEl.style.minHeight = `${Math.max(640, maxY + 180)}px`;
       edgesEl.innerHTML = g.edges.map(e => {
         const s = pos[e.source], t = pos[e.target];
         if (!s || !t) return "";


### PR DESCRIPTION
## Summary
- Improve Task Workspace UX for real operations
- Add task board + detail interaction and filter/search flow
- Improve chat UX with room creation and message pagination
- Add autosync controls/status/error feedback for real data sync
- Improve websocket reconnection/heartbeat observability in UI

## Changes
- UI (`/ui`, `api/static/office.html`):
  - Board/Graph mode toggle
  - Status/agent/team/query filters
  - Click-to-focus task detail panel
  - Chat room create controls
  - Load older messages (before_id pagination)
  - Sender type styling (user/agent/system)
  - Auto-sync toggle + interval selector
  - Last sync / sync status / websocket RTT indicators
  - Sync source URL input
- API:
  - `GET /api/agent-chat/messages` now supports `before_id`

## Validation
- py_compile passed for updated backend modules
- Runtime checks passed on temp port:
  - room create/send/list
  - before_id pagination
  - sync controls markers rendered in `/ui`
  - integration sync success when agent_office source is running

## Notes
- Operating port remains `8765`
- Validation used temporary port where needed to avoid conflicts
